### PR TITLE
rts/configure: derive extra-libraries from LIBS (dl, pthread)

### DIFF
--- a/m4/fp_check_pthreads.m4
+++ b/m4/fp_check_pthreads.m4
@@ -12,22 +12,7 @@ AC_DEFUN([FP_CHECK_PTHREAD_LIB],
   dnl
   dnl Note that it is important that this happens before we AC_CHECK_LIB(thread)
   AC_MSG_CHECKING(whether -lpthread is needed for pthreads)
-  AC_CHECK_FUNC(pthread_create,
-      [
-          AC_MSG_RESULT(no)
-          UseLibpthread=NO
-      ],
-      [
-          AC_CHECK_LIB(pthread, pthread_create,
-              [
-                  AC_MSG_RESULT(yes)
-                  UseLibpthread=YES
-              ],
-              [
-                  AC_MSG_RESULT([no pthreads support found.])
-                  UseLibpthread=NO
-              ])
-      ])
+  AC_SEARCH_LIBS([pthread_create],[pthread])
 ])
 
 # FP_CHECK_PTHREAD_FUNCS
@@ -37,6 +22,7 @@ AC_DEFUN([FP_CHECK_PTHREAD_LIB],
 # `AC_DEFINE`s various C `HAVE_*` macros.
 AC_DEFUN([FP_CHECK_PTHREAD_FUNCS],
 [
+  OLD_LIBS=$LIBS
   dnl Setting thread names
   dnl ~~~~~~~~~~~~~~~~~~~~
   dnl The portability situation here is complicated:
@@ -123,4 +109,5 @@ AC_DEFUN([FP_CHECK_PTHREAD_FUNCS],
   )
 
   AC_CHECK_FUNCS_ONCE([pthread_condattr_setclock])
+  LIBS=$OLD_LIBS
 ])

--- a/rts/configure.ac
+++ b/rts/configure.ac
@@ -178,7 +178,7 @@ dnl Check for libraries
 dnl ################################################################
 
 dnl ** check whether we need -ldl to get dlopen()
-AC_CHECK_LIB([dl], [dlopen], [HAVE_LIBDL=1])
+AC_SEARCH_LIBS([dlopen], [dl])
 dnl ** check whether we have dlinfo
 AC_CHECK_FUNCS([dlinfo])
 
@@ -523,14 +523,9 @@ cat $srcdir/rts.buildinfo.in \
 rm -f external-symbols.flags
 ]
 
+AC_SUBST([EXTRA_LIBS],[` printf " %s " "$LIBS" | sed -E 's/ -l([[^ ]]*)/\1 /g' `])
 AS_IF(
-  [test "$HAVE_LIBDL" = 1],
-  [EXTRA_LIBS="$EXTRA_LIBS dl"])
-AS_IF(
-  [test "$UseLibpthread" = "YES"]
-  [EXTRA_LIBS="$EXTRA_LIBS pthread"])
-AS_IF(
-  [test "x$EXTRA_LIBS" != "x"]
+  [test "`echo $EXTRA_LIBS | sed 's/ //'`" != ""],
   [echo "extra-libraries: $EXTRA_LIBS" >> rts.buildinfo])
 
 dnl --------------------------------------------------------------


### PR DESCRIPTION
Cherry-pick only m4/fp_check_pthreads.m4 and rts/configure.ac changes from 09400675192e394fc70badfd1eedc38bfe0ad3b9 onto stable-ghc-9.14.

Fixes the cabal failure introduced by 7442ca3f8b3d737a714dec76df9573beed8059de:

Missing (or bad) C libraries: dl, pthread

We now rely on AC_SEARCH_LIBS for dlopen() and pthread_create and derive extra-libraries from LIBS instead of manual bookkeeping via HAVE_LIBDL/UseLibpthread variables.

This ensures platforms requiring explicit -ldl/-lpthread are covered while not adding them unnecessarily where they aren't needed.

Cherry-picked-from: 09400675192e394fc70badfd1eedc38bfe0ad3b9