### PR TITLE
Remove need-pthread flag from rts.cabal

### DIFF
--- a/rts/rts.cabal
+++ b/rts/rts.cabal
@@ -262,9 +262,6 @@ flag librt
 flag libffi-adjustors
   default: False
   manual: True
-flag need-pthread
-  default: False
-  manual: True
 flag libbfd
   default: False
   manual: True
@@ -559,8 +556,6 @@ common rts-link-options
           psapi
        cpp-options: -D_WIN32_WINNT=0x06010000
        cc-options: -D_WIN32_WINNT=0x06010000
-    if flag(need-pthread)
-       extra-libraries: pthread
     if flag(need-atomic)
        extra-libraries: atomic
     if flag(libbfd)


### PR DESCRIPTION
In 7442ca3f8b3d737a714dec76df9573beed8059de we changed the rts's configure script to properly detect the need for pthread and ld.

We can now also remove the `need-pthread` flag.