### PR TITLE
[!14773] ghc-pkg: Add support for mermaid diagram generation for markdown files

### DIFF
--- a/utils/ghc-pkg/Main.hs
+++ b/utils/ghc-pkg/Main.hs
@@ -268,6 +268,10 @@ usageHeader prog = substProg prog $
   "    for input for the graphviz tools.  For example, to generate a PDF\n" ++
   "    of the dependency graph: ghc-pkg dot | tred | dot -Tpdf >pkgs.pdf\n" ++
   "\n" ++
+  "  $p mermaid\n" ++
+  "    Generate a graph of the package dependencies in Mermaid format\n" ++
+  "    suitable for embedding in Markdown files.\n" ++
+  "\n" ++
   "  $p find-module {module}\n" ++
   "    List registered packages exposing module {module} in the global\n" ++
   "    database, and also the user database if --user is given.\n" ++
@@ -464,6 +468,8 @@ runit verbosity cli nonopts = do
                                  (Just (Substring pkgarg_str m)) Nothing
     ["dot"] -> do
         showPackageDot verbosity cli
+    ["mermaid"] -> do
+        showPackageMermaid verbosity cli
     ["find-module", mod_name] -> do
         let match = maybe (==mod_name) id (substringCheck mod_name)
         listPackages verbosity cli Nothing (Just match)
@@ -1642,6 +1648,27 @@ showPackageDot verbosity myflags = do
                    let to = display (mungedId dep)
                  ]
   putStrLn "}"
+
+showPackageMermaid :: Verbosity -> [Flag] -> IO ()
+showPackageMermaid verbosity myflags = do
+  (_, GhcPkg.DbOpenReadOnly, flag_db_stack) <-
+    getPkgDatabases verbosity GhcPkg.DbOpenReadOnly
+      False{-use user-} True{-use cache-} False{-expand vars-} myflags
+
+  let all_pkgs = allPackagesInStack flag_db_stack
+      ipix  = PackageIndex.fromList all_pkgs
+
+  putStrLn "```mermaid"
+  putStrLn "graph TD"
+  mapM_ putStrLn [ "  " ++ from ++ " --> " ++ to
+                 | p <- all_pkgs,
+                   let from = display (mungedId p),
+                   key <- depends p,
+                   Just dep <- [PackageIndex.lookupUnitId ipix key],
+                   let to = display (mungedId dep)
+                 ]
+  putStrLn "```"
+
 
 -- -----------------------------------------------------------------------------
 -- Prints the highest (hidden or exposed) version of a package


### PR DESCRIPTION
mermaid is a common diagram format that can be inlined in markdown files, and e.g. github will even render it.  This change adds support for mermaid diagram output to ghc-pkg.

Upstream MR: [!14773](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14773)