### PR TITLE
[!14775] Print fully qualified unit names in name mismatch

### DIFF
--- a/compiler/GHC/Iface/Errors/Ppr.hs
+++ b/compiler/GHC/Iface/Errors/Ppr.hs
@@ -336,8 +336,10 @@ hiModuleNameMismatchWarn requested_mod read_mod
             ]
         ]
  | otherwise =
-  -- ToDo: This will fail to have enough qualification when the package IDs
-  -- are the same
+  -- Display fully qualified unit names by enabling ppr-debug. Otherwise we
+  -- may not have enough qualification and the printed names could look exactly
+  -- the same.
+  updSDocContext (\ctx -> ctx { sdocPprDebug = True}) $
   withPprStyle (mkUserStyle alwaysQualify AllTheWay) $
     -- we want the Modules below to be qualified with package names,
     -- so reset the NamePprCtx setting.
@@ -345,7 +347,6 @@ hiModuleNameMismatchWarn requested_mod read_mod
          , ppr requested_mod
          , text "differs from name found in the interface file"
          , ppr read_mod
-         , parens (text "if these names look the same, try again with -dppr-debug")
          ]
 
 dynamicHashMismatchError :: Module -> ModLocation -> SDoc


### PR DESCRIPTION
It's more user-friendly to directly print the right thing instead of requiring the user to retry with the additional `-dppr-debug` flag.

Upstream MR: [!14775](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14775)