### PR TITLE
[!14766] Fix some tests (statically linked GHC vs libc)

### DIFF
--- a/testsuite/tests/ffi/should_run/T1288_c.c
+++ b/testsuite/tests/ffi/should_run/T1288_c.c
@@ -3,4 +3,5 @@
 void test(int arg)
 {
    printf("The argument passed was %i\n", arg );
+   fflush(NULL);
 }

--- a/testsuite/tests/ffi/should_run/T1288_ghci_c.c
+++ b/testsuite/tests/ffi/should_run/T1288_ghci_c.c
@@ -3,4 +3,5 @@
 void test(int arg)
 {
    printf("The argument passed was %i\n", arg );
+   fflush(NULL);
 }

--- a/testsuite/tests/ffi/should_run/T2276_c.c
+++ b/testsuite/tests/ffi/should_run/T2276_c.c
@@ -3,4 +3,5 @@
 void test(int arg)
 {
    printf("The argument passed was %i\n", arg );
+   fflush(NULL);
 }

--- a/testsuite/tests/ffi/should_run/T2276_ghci_c.c
+++ b/testsuite/tests/ffi/should_run/T2276_ghci_c.c
@@ -3,4 +3,5 @@
 void test(int arg)
 {
    printf("The argument passed was %i\n", arg );
+   fflush(NULL);
 }

--- a/testsuite/tests/ghci/scripts/T7388.hs
+++ b/testsuite/tests/ghci/scripts/T7388.hs
@@ -2,5 +2,7 @@
 module T7388 where
 
 import Foreign.C
+import Foreign.Ptr
 
 foreign import capi "stdio.h printf" printfb :: CString -> CInt -> IO ()
+foreign import capi "stdio.h fflush" fflushb :: Ptr () -> IO ()

--- a/testsuite/tests/ghci/scripts/T7388.script
+++ b/testsuite/tests/ghci/scripts/T7388.script
@@ -1,2 +1,5 @@
 :l T7388
 withCString "I am a working CApi FFI call\n" $ \str -> printfb str 0
+-- don't forget to flush, otherwise when ghc is statically linked, the C stdout
+-- buffer is never flushed.
+fflushb nullPtr

--- a/testsuite/tests/th/T16180.hs
+++ b/testsuite/tests/th/T16180.hs
@@ -23,10 +23,19 @@ $(do
       , "_mydata:"
       , ".ascii \"Hello world\\0\""
       ]
+#elif defined(mingw32_HOST_OS)
+      [ ".global \"mydata\""
+      , "mydata:"
+      , ".ascii \"Hello world\\0\""
+      ]
 #else
       [ ".global \"mydata\""
       , "mydata:"
       , ".ascii \"Hello world\\0\""
+        -- make recent linkers happy by explicitly not requiring an executable
+        -- stack. Without this section we get:
+        --    warning: <file>: missing .note.GNU-stack section implies executable stack
+      , ".section .note.GNU-stack,\"\",@progbits"
       ]
 #endif
    return [])


### PR DESCRIPTION
1. T16180: indicate that the stack isn't executable
2. Fix some tests (statically linked GHC vs libc)

   When GHC is linked statically, the stdout C global variable that GHC uses isn't shared with the stdout C global variable used by loaded code.

   As a consequence, the latter must be explicitly flushed because GHC won't flush it before exiting.

Upstream MR: [!14766](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14766)