### PR TITLE
[!14785] test.mk expect GhcLeadingUnderscore, not LeadingUnderscore (in line w…

### DIFF
--- a/testsuite/ghc-config/ghc-config.hs
+++ b/testsuite/ghc-config/ghc-config.hs
@@ -43,7 +43,7 @@ main = do
   getGhcFieldOrDefault fields "TargetRTSLinkerOnlySupportsSharedLibs" "target RTS linker only supports shared libraries" "NO"
   getGhcFieldOrDefault fields "GhcDynamic" "GHC Dynamic" "NO"
   getGhcFieldOrDefault fields "GhcProfiled" "GHC Profiled" "NO"
-  getGhcFieldOrDefault fields "LeadingUnderscore" "Leading underscore" "NO"
+  getGhcFieldOrDefault fields "GhcLeadingUnderscore" "Leading underscore" "NO"
   getGhcFieldOrDefault fields "GhcTablesNextToCode" "Tables next to code" "NO"
   getGhcFieldProgWithDefault fields "AR" "ar command" "ar"
   getGhcFieldProgWithDefault fields "LLC" "LLVM llc command" "llc"


### PR DESCRIPTION
…ith the other Ghc prefixed variables.

Upstream MR: [!14785](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14785)