### PR TITLE
[!14788] testsuite: clarify Windows/Darwin locale rationale for skipping T6037…

### DIFF
--- a/testsuite/tests/driver/all.T
+++ b/testsuite/tests/driver/all.T
@@ -179,24 +179,23 @@ test('T7060', [], makefile_test, [])
 test('T7130', normal, compile_fail, ['-fflul-laziness'])
 test('T7563', when(unregisterised(), skip), makefile_test, [])
 test('T6037',
-     # The testsuite doesn't know how to set a non-Unicode locale on Windows or MacOS < Sonoma.
-     # Because in previous version of MacOS the test is still broken, we mark it as fragile.
+     # Requires forcing a 7-bit/ASCII-only locale.
+     # - On Windows (mingw32) the testsuite can't reliably set a non-Unicode C locale -> expect_fail.
+     # - On modern Darwin there are no pure ASCII locales available -> skip.
      [when(opsys('mingw32'), expect_fail),
-      when(opsys('darwin'), fragile(24161))
+      when(opsys('darwin'), skip)
      ],
      makefile_test, [])
 test('T2507',
-     # The testsuite doesn't know how to set a non-Unicode locale on Windows or MacOS < Sonoma
-     # Because in previous version of MacOS the test is still broken, we mark it as fragile.
+     # Same locale assumptions as T6037 (ASCII-only needed, unavailable on Darwin; untestable on Windows).
      [when(opsys('mingw32'), expect_fail),
-      when(opsys('darwin'), fragile(24161))
+      when(opsys('darwin'), skip)
      ],
      makefile_test, [])
 test('T8959a',
-     # The testsuite doesn't know how to set a non-Unicode locale on Windows or MacOS < Sonoma
-     # Because in previous version of MacOS the test is still broken, we mark it as fragile.
+     # Same locale assumptions as T6037 (ASCII-only needed, unavailable on Darwin; untestable on Windows).
      [when(opsys('mingw32'), expect_fail),
-      when(opsys('darwin'), fragile(24161))
+      when(opsys('darwin'), skip)
      ],
      makefile_test, [])
 


### PR DESCRIPTION
… T2507 T8959a

Upstream MR: [!14788](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14788)