### PR TITLE
[!14789] Skip broken tests on macOS (due to leading underscore not handled pro…

### DIFF
--- a/testsuite/tests/rts/linker/T11223/all.T
+++ b/testsuite/tests/rts/linker/T11223/all.T
@@ -33,7 +33,12 @@ test('T11223_simple_duplicate',
 
 test('T11223_simple_duplicate_lib',
      [extra_files(['bar.c', 'foo.c', 'foo.hs']),
-      when(ghc_dynamic(), skip), normalise_errmsg_fun(normalise_duplicate_errmsg),
+     when(ghc_dynamic(), skip),
+     # Darwin/Mach-O reports external C symbols with a leading underscore (e.g. _a, _c)
+     # which our expected stderr (shared with ELF platforms) does not account for.
+     # Rather than broaden normalisation here, skip on darwin for now.
+     when(opsys('darwin'), skip),
+     normalise_errmsg_fun(normalise_duplicate_errmsg),
       req_c],
      makefile_test, ['t_11223_simple_duplicate_lib'])
 
@@ -57,7 +62,10 @@ test('T11223_link_order_b_a_succeed',
 
 test('T11223_link_order_a_b_2_fail',
      [extra_files(['bar.c', 'foo.c', 'foo3.hs']),
-      when(ghc_dynamic(), skip), normalise_errmsg_fun(normalise_duplicate_errmsg),
+     when(ghc_dynamic(), skip),
+     # See note above about Mach-O leading underscores; skip on darwin.
+     when(opsys('darwin'), skip),
+     normalise_errmsg_fun(normalise_duplicate_errmsg),
       req_c],
      makefile_test, ['t_11223_link_order_a_b_2_fail'])
 


### PR DESCRIPTION
…perly in the expected output.)

Upstream MR: [!14789](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14789)