### PR TITLE
[!14795] deriveConstant: support symbols in the .bss section (#26393)

### DIFF
--- a/hadrian/src/Settings/Builders/DeriveConstants.hs
+++ b/hadrian/src/Settings/Builders/DeriveConstants.hs
@@ -48,4 +48,4 @@ includeCcArgs = do
             , arg "-Irts/include"
             , arg $ "-I" ++ rtsPath </> "include"
             , notM targetSupportsSMP ? arg "-DNOSMP"
-            , arg "-fcommon" ]
+            ]

--- a/utils/deriveConstants/Main.hs
+++ b/utils/deriveConstants/Main.hs
@@ -842,8 +842,9 @@ getWanted verbose os tmpdir gccProgram gccFlags nmProgram mobjdumpProgram
           parseNmLine line
               = case words line of
                 ('_' : n) : "C" : s : _ -> mkP n s
-                n : "C" : s : _ -> mkP n s
-                [n, "D", _, s] -> mkP n s
+                n : "C" : s : _         -> mkP n s -- in common section
+                n : "B" : _off : s : _  -> mkP n s -- in .bss section
+                [n, "D", _, s]          -> mkP n s
                 [s, "O", "*COM*", _, n] -> mkP n s
                 _ -> Nothing
               where mkP r s = case (stripPrefix prefix r, readHex s) of


### PR DESCRIPTION
By mistake we tried to use deriveConstant without passing `--gcc-flag -fcommon` (which Hadrian does) and it failed.

This patch adds deriveConstant support for constants stored in the .bss section so that deriveConstant works without passing `-fcommon` to the C compiler.

Upsteram MR: [!14795](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14795)