### PR TITLE
rts: Build Hash.c with optimizations

### DIFF
--- a/rts/rts.cabal
+++ b/rts/rts.cabal
@@ -386,7 +386,7 @@ common rts-c-sources-base
                FileLock.c
                ForeignExports.c
                Globals.c
-               Hash.c
+               Hash.c (-O3)
                Heap.c
                Hpc.c
                HsFFI.c


### PR DESCRIPTION
The source hack will be removed in upstream: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14848