### PR TITLE
refactor: reorganize cabal.project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,9 +231,6 @@ GIT_COMMIT_ID
 .bash_history
 .gitconfig
 
-# Should be equal to testdir_suffix from testsuite/driver/testlib.py.
-*.run
-
 # -----------------------------------------------------------------------------
 # ghc.nix
 ghc.nix/

--- a/Makefile
+++ b/Makefile
@@ -975,9 +975,14 @@ _build/bindist/tests.tar.gz:
 
 $(GHC1) $(GHC2): | hackage
 hackage: _build/packages/hackage.haskell.org/01-index.tar.gz
+
+# Always run cabal update. This makes sure that the index file won't go stale,
+# whatever index-state we set in the project file. Reproducibility is left to
+# index-state.
+.PHONY: _build/packages/hackage.haskell.org/01-index.tar.gz
 _build/packages/hackage.haskell.org/01-index.tar.gz: | $(CABAL)
 	@mkdir -p $(@D)
-	$(CABAL) $(CABAL_ARGS) update --index-state @1745256340
+	$(CABAL) $(CABAL_ARGS) update
 
 # --- Configure and source preparation ---
 

--- a/cabal.project.rts
+++ b/cabal.project.rts
@@ -1,0 +1,51 @@
+-- NOTE: Yes. The strings have to be escaped like this.
+ 
+package rts
+  ghc-options: "-optc-DProjectVersion=\"914\""
+  ghc-options: "-optc-DBuildPlatform=\"FIXME\""
+  ghc-options: "-optc-DBuildArch=\"FIXME\""
+  ghc-options: "-optc-DBuildOS=\"FIXME\""
+  ghc-options: "-optc-DBuildVendor=\"FIXME\""
+  ghc-options: "-optc-DGhcUnregisterised=\"FIXME\""
+  ghc-options: "-optc-DTablesNextToCode=\"FIXME\""
+  ghc-options: "-optc-DFS_NAMESPACE=rts"
+  ghc-options: -no-rts
+  flags: +tables-next-to-code
+
+if os(linux)
+  package rts
+    ghc-options: "-optc-DHostArch=\"x86_64\""
+    ghc-options: "-optc-DHostOS=\"linux\""
+    ghc-options: "-optc-DHostPlatform=\"x86_64-unknown-linux\""
+    ghc-options: "-optc-DHostVendor=\"unknown\""
+
+if os(darwin)
+  package rts
+    ghc-options: "-optc-DHostArch=\"aarch64\""
+    ghc-options: "-optc-DHostOS=\"darwin\""
+    ghc-options: "-optc-DHostPlatform=\"aarch64-apple-darwin\""
+    ghc-options: "-optc-DHostVendor=\"unknown\""
+    flags: +leading-underscore
+
+if os(freebsd)
+  package rts
+    ghc-options: "-optc-DHostArch=\"x86_64\""
+    ghc-options: "-optc-DHostOS=\"freebsd\""
+    ghc-options: "-optc-DHostPlatform=\"x86_64-portbld-freebsd\""
+    ghc-options: "-optc-DHostVendor=\"unknown\""
+
+if os(wasi)
+  package rts
+    ghc-options: "-optc-DHostArch=\"wasm32\""
+    ghc-options: "-optc-DHostOS=\"unknown\""
+    ghc-options: "-optc-DHostPlatform=\"wasm32-wasi\""
+    ghc-options: "-optc-DHostVendor=\"unknown\""
+    ghc-options: -optl-Wl,--export-dynamic
+    ghc-options: -optc-fvisibility=default
+    ghc-options: -optc-fvisibility-inlines-hidden
+
+package rts-headers
+  ghc-options: -no-rts
+
+package rts-fs
+  ghc-options: -no-rts

--- a/cabal.project.stage1
+++ b/cabal.project.stage1
@@ -1,3 +1,5 @@
+index-state: 2025-10-26T19:17:08Z
+
 packages:
   -- NOTE: we need rts-headers, because the _newly_ built compiler depends
   --       on these potentially _new_ headers, we must not rely on those from
@@ -35,6 +37,7 @@ packages:
   utils/deriveConstants
   utils/ghc-toolchain
   utils/ghc-toolchain/exe
+
 
 benchmarks: False
 tests: False

--- a/cabal.project.stage1
+++ b/cabal.project.stage1
@@ -1,4 +1,7 @@
 index-state: 2025-10-26T19:17:08Z
+allow-boot-library-installs: True
+benchmarks: False
+tests: False
 
 packages:
   -- NOTE: we need rts-headers, because the _newly_ built compiler depends
@@ -10,38 +13,49 @@ packages:
   rts-headers
   rts-fs
 
-  -- other packages.
+  -- Compiler
   ghc
   compiler
-  libraries/directory
-  libraries/file-io
-  libraries/filepath
-  libraries/ghc-platform
+
+  -- Internal libraries
   libraries/ghc-boot
   libraries/ghc-boot-th-next
   libraries/ghci
   libraries/libffi-clib
+
+  -- Internal tools
+  utils/deriveConstants
+  utils/genapply
+  utils/genprimopcode
+  utils/ghc-pkg
+  utils/ghc-toolchain
+  utils/ghc-toolchain/exe
+  utils/unlit
+
+  -- The following are packages available on Hackage but included as submodules
+  libraries/Cabal/Cabal
+  libraries/Cabal/Cabal-syntax
+  libraries/directory
+  libraries/file-io
+  libraries/filepath
   libraries/os-string
   libraries/process
   libraries/semaphore-compat
---  libraries/time
   libraries/unix
   libraries/Win32
-  libraries/Cabal/Cabal-syntax
-  libraries/Cabal/Cabal
-  utils/ghc-pkg
   utils/hsc2hs
-  utils/unlit
-  utils/genprimopcode
-  utils/genapply
-  utils/deriveConstants
-  utils/ghc-toolchain
-  utils/ghc-toolchain/exe
 
 
-benchmarks: False
-tests: False
-allow-boot-library-installs: True
+--
+-- Constraints
+--
+
+constraints:
+  template-haskell <= 2.22
+
+--
+-- Package level configuration
+--
 
 package *
   library-vanilla: True
@@ -66,8 +80,9 @@ package ghc-boot-th-next
 package hsc2hs
   flags: +in-ghc-tree
 
-constraints:
-  template-haskell <= 2.22
+--
+-- Program options
+--
 
 program-options
   ghc-options: -fhide-source-paths -j

--- a/cabal.project.stage1
+++ b/cabal.project.stage1
@@ -21,6 +21,7 @@ packages:
   libraries/ghc-boot
   libraries/ghc-boot-th-next
   libraries/ghci
+  libraries/ghc-platform
   libraries/libffi-clib
 
   -- Internal tools

--- a/cabal.project.stage2
+++ b/cabal.project.stage2
@@ -1,41 +1,65 @@
-package-dbs: clear, global
+allow-boot-library-installs: True
+benchmarks: False
+tests: False
+
+-- Disable Hackage, we explicitly include the packages we need.
+active-repositories: :none
 
 -- Import configure/generated feature toggles (dynamic, etc.) if present.
 -- A default file is kept in-tree; configure will overwrite with substituted values.
 import: cabal.project.stage2.settings
 
 packages:
+  -- RTS
   rts-headers
   rts-fs
   rts
 
-  libraries/ghc-prim
-  libraries/ghc-internal
-  libraries/ghc-experimental
-  libraries/base
+  -- Compiler
   compiler
   ghc
-  libraries/ghc-platform
-  libraries/ghc-compact
+
+  -- Internal libraries
+  libraries/base
   libraries/ghc-bignum
-  libraries/integer-gmp
   libraries/ghc-boot
   libraries/ghc-boot-th
+  libraries/ghc-compact
+  libraries/ghc-experimental
   libraries/ghc-heap
+  libraries/ghc-internal
+  libraries/ghc-platform
+  libraries/ghc-prim
   libraries/ghci
-  libraries/stm
-  libraries/template-haskell
-  libraries/hpc
+  libraries/integer-gmp
   libraries/system-cxx-std-lib
+  libraries/template-haskell
+
+  -- Internal tools
+  utils/deriveConstants
+  utils/genapply
+  utils/genprimopcode
+  utils/ghc-iserv
+  utils/ghc-pkg
+  utils/ghc-toolchain
+  utils/hp2ps
+  utils/runghc
+  utils/unlit
+
+  -- The following are packages available on Hackage but included as submodules
   libraries/array
   libraries/binary
   libraries/bytestring
+  libraries/Cabal/Cabal
+  libraries/Cabal/Cabal-syntax
   libraries/containers/containers
   libraries/deepseq
   libraries/directory
   libraries/exceptions
   libraries/file-io
   libraries/filepath
+  libraries/haskeline
+  libraries/hpc
   libraries/libffi-clib
   libraries/mtl
   libraries/os-string
@@ -43,40 +67,26 @@ packages:
   libraries/pretty
   libraries/process
   libraries/semaphore-compat
+  libraries/stm
+  libraries/terminfo
   libraries/text
   libraries/time
   libraries/transformers
   libraries/unix
-  libraries/xhtml
   libraries/Win32
+  libraries/xhtml
+  utils/hpc
+  utils/hsc2hs
 
-  libraries/Cabal/Cabal-syntax
-  libraries/Cabal/Cabal
+  -- These would be on Hackage but we include them as direct URLs
+  -- (Hackage is disabled by `active-repositories: :none`)
   https://hackage.haskell.org/package/alex-3.5.2.0/alex-3.5.2.0.tar.gz
   https://hackage.haskell.org/package/happy-2.1.5/happy-2.1.5.tar.gz
   https://hackage.haskell.org/package/happy-lib-2.1.5/happy-lib-2.1.5.tar.gz
 
-  utils/genprimopcode
-  utils/deriveConstants
-  utils/ghc-pkg
-  utils/hsc2hs
-  utils/unlit
-  utils/ghc-toolchain
-
-  libraries/haskeline
-  libraries/terminfo
-  utils/hp2ps
-  utils/hpc
-  utils/ghc-iserv
-  utils/genapply
-  utils/runghc
-
--- project-rts
--- project-ghc
-benchmarks: False
-tests: False
-allow-boot-library-installs: True
-active-repositories: :none
+--
+-- Constraints
+--
 
 constraints:
   -- we do not want to use the rts-headers from stage1
@@ -84,6 +94,10 @@ constraints:
   -- All build dependencies should be installed, i.e. from stage1.
   -- I cannot write build:* but ghc-internal is enough to do the job.
   , build:any.ghc-internal installed
+
+--
+-- Package level configuration
+--
 
 package *
   library-vanilla: True
@@ -93,74 +107,7 @@ package *
   executable-profiling: False
   executable-static: False
 
--- Maybe we should fix this with some import
-if os(linux)
-  package rts
-    ghc-options: "-optc-DProjectVersion=\"914\""
-    ghc-options: "-optc-DHostPlatform=\"x86_64-unknown-linux\""
-    ghc-options: "-optc-DHostArch=\"x86_64\""
-    ghc-options: "-optc-DHostOS=\"linux\""
-    ghc-options: "-optc-DHostVendor=\"unknown\""
-    ghc-options: "-optc-DBuildPlatform=\"FIXME\""
-    ghc-options: "-optc-DBuildArch=\"FIXME\""
-    ghc-options: "-optc-DBuildOS=\"FIXME\""
-    ghc-options: "-optc-DBuildVendor=\"FIXME\""
-    ghc-options: "-optc-DGhcUnregisterised=\"FIXME\""
-    ghc-options: "-optc-DTablesNextToCode=\"FIXME\""
-    ghc-options: "-optc-DFS_NAMESPACE=rts"
-    flags: +tables-next-to-code
-
-if os(darwin)
-  package rts
-    ghc-options: "-optc-DProjectVersion=\"914\""
-    ghc-options: "-optc-DHostPlatform=\"aarch64-apple-darwin\""
-    ghc-options: "-optc-DHostArch=\"aarch64\""
-    ghc-options: "-optc-DHostOS=\"darwin\""
-    ghc-options: "-optc-DHostVendor=\"unknown\""
-    ghc-options: "-optc-DBuildPlatform=\"FIXME\""
-    ghc-options: "-optc-DBuildArch=\"FIXME\""
-    ghc-options: "-optc-DBuildOS=\"FIXME\""
-    ghc-options: "-optc-DBuildVendor=\"FIXME\""
-    ghc-options: "-optc-DGhcUnregisterised=\"FIXME\""
-    ghc-options: "-optc-DTablesNextToCode=\"FIXME\""
-    ghc-options: "-optc-DFS_NAMESPACE=rts"
-    flags: +tables-next-to-code +leading-underscore
-
-if os(freebsd)
-  package rts
-    ghc-options: "-optc-DProjectVersion=\"914\""
-    ghc-options: "-optc-DHostPlatform=\"x86_64-portbld-freebsd\""
-    ghc-options: "-optc-DHostArch=\"x86_64\""
-    ghc-options: "-optc-DHostOS=\"freebsd\""
-    ghc-options: "-optc-DHostVendor=\"unknown\""
-    ghc-options: "-optc-DBuildPlatform=\"FIXME\""
-    ghc-options: "-optc-DBuildArch=\"FIXME\""
-    ghc-options: "-optc-DBuildOS=\"FIXME\""
-    ghc-options: "-optc-DBuildVendor=\"FIXME\""
-    ghc-options: "-optc-DGhcUnregisterised=\"FIXME\""
-    ghc-options: "-optc-DTablesNextToCode=\"FIXME\""
-    ghc-options: "-optc-DFS_NAMESPACE=rts"
-    flags: +tables-next-to-code
-
-program-options
-  ghc-options: -fhide-source-paths -j
-
--- project-boot-libs
-benchmarks: False
-tests: False
-allow-boot-library-installs: True
-active-repositories: :none
-
--- (removed duplicate global package * stanza; first one applies already)
-
-package rts-headers
-  ghc-options: -no-rts
-
-package rts-fs
-  ghc-options: -no-rts
-
-package rts
-  ghc-options: -no-rts
+import: cabal.project.rts
 
 package libffi-clib
   ghc-options: -no-rts
@@ -196,32 +143,33 @@ package libffi-clib
 --        throughout the session. See
 --          GHC.Unit.State:mkUnitState
 --
-package ghc-internal
-  ghc-options: -no-rts
 
 package ghc
   flags: +build-tool-depends +internal-interpreter
+
+package ghc-bin
+  flags: +internal-interpreter -threaded
 
 package ghci
   flags: +internal-interpreter
 
 package ghc-internal
   flags: +bignum-native
+  ghc-options: -no-rts
 
 package text
   flags: -simdutf
 
-program-options
-  ghc-options: -fhide-source-paths -j
-
-package ghc-bin
-  flags: +internal-interpreter -threaded
-
+-- TODO: What is this? Why do we need _in-ghc-tree_ here?
 package hsc2hs
   flags: +in-ghc-tree
 
 package haskeline
   flags: -terminfo
+
+--
+-- Program options
+--
 
 program-options
   ghc-options: -fhide-source-paths -j

--- a/cabal.project.stage3
+++ b/cabal.project.stage3
@@ -1,37 +1,52 @@
-package-dbs: clear, global
+allow-boot-library-installs: True
+benchmarks: False
+tests: False
 
+-- Disable Hackage, we explicitly include the packages we need.
+active-repositories: :none
 
 packages:
+  -- RTS
   rts-headers
   rts-fs
   rts
 
-  libraries/ghc-prim
-  libraries/ghc-internal
-  libraries/ghc-experimental
-  libraries/base
+  -- Compiler
   compiler
-  libraries/ghc-platform
-  libraries/ghc-compact
+
+  -- Internal libraries
+  libraries/base
   libraries/ghc-bignum
-  libraries/integer-gmp
   libraries/ghc-boot
   libraries/ghc-boot-th
+  libraries/ghc-compact
+  libraries/ghc-experimental
   libraries/ghc-heap
+  libraries/ghc-internal
+  libraries/ghc-platform
+  libraries/ghc-prim
   libraries/ghci
-  libraries/stm
-  libraries/template-haskell
-  libraries/hpc
+  libraries/integer-gmp
   libraries/system-cxx-std-lib
+  libraries/template-haskell
+
+  -- Internal tools
+  utils/genprimopcode
+  utils/deriveConstants
+
+  -- The following are packages available on Hackage but included as submodules
   libraries/array
   libraries/binary
   libraries/bytestring
+  libraries/Cabal/Cabal
+  libraries/Cabal/Cabal-syntax
   libraries/containers/containers
   libraries/deepseq
   libraries/directory
   libraries/exceptions
   libraries/file-io
   libraries/filepath
+  libraries/hpc
   libraries/libffi-clib
   libraries/mtl
   libraries/os-string
@@ -39,30 +54,30 @@ packages:
   libraries/pretty
   libraries/process
   libraries/semaphore-compat
+  libraries/stm
   libraries/text
   libraries/time
   libraries/transformers
   libraries/unix
-  libraries/xhtml
   libraries/Win32
-
-  libraries/Cabal/Cabal-syntax
-  libraries/Cabal/Cabal
+  libraries/xhtml
+  
+  -- These would be on Hackage but we include them as direct URLs
+  -- (Hackage is disabled by `active-repositories: :none`)
   https://hackage.haskell.org/package/alex-3.5.2.0/alex-3.5.2.0.tar.gz
   https://hackage.haskell.org/package/happy-2.1.5/happy-2.1.5.tar.gz
   https://hackage.haskell.org/package/happy-lib-2.1.5/happy-lib-2.1.5.tar.gz
 
-  utils/genprimopcode
-  utils/deriveConstants
-
--- project-rts
-benchmarks: False
-tests: False
-allow-boot-library-installs: True
-active-repositories: :none
+--
+-- Constraints
+--
 
 constraints:
+  -- I cannot write build:* but ghc-internal is enough to do the job.
+  -- FIXME: it should be possible to write build:*
+  -- All build dependencies should be installed, i.e. from stage1.
   build:any.ghc-internal installed,
+
   -- for some reason cabal things these are already installed for the target,
   -- although they only exist in the build compiler package db
   Cabal source,
@@ -98,6 +113,9 @@ constraints:
   xhtml source,
   Win32 source
 
+--
+-- Package level configuration
+--
 
 package *
   library-vanilla: True
@@ -105,6 +123,7 @@ package *
   executable-profiling: False
   executable-dynamic: False
   executable-static: False
+  
   -- library-for-ghci will cause a `ld -r` call to create pre-linked objects.
   -- This helps the internal linker when trying to link (.a) archives with massive
   -- displacements. In that case the displacement can be in excess of what
@@ -126,90 +145,8 @@ package *
 if os(wasi)
   package *
     shared: True
-  package rts
-    ghc-options: "-optc-DProjectVersion=\"913\""
-    ghc-options: "-optc-DHostPlatform=\"wasm32-wasi\""
-    ghc-options: "-optc-DHostArch=\"wasm32\""
-    ghc-options: "-optc-DHostOS=\"unknown\""
-    ghc-options: "-optc-DHostVendor=\"unknown\""
-    ghc-options: "-optc-DBuildPlatform=\"FIXME\""
-    ghc-options: "-optc-DBuildArch=\"FIXME\""
-    ghc-options: "-optc-DBuildOS=\"FIXME\""
-    ghc-options: "-optc-DBuildVendor=\"FIXME\""
-    ghc-options: "-optc-DGhcUnregisterised=\"FIXME\""
-    ghc-options: "-optc-DTablesNextToCode=\"FIXME\""
-    ghc-options: "-optc-DFS_NAMESPACE=rts"
-    ghc-options: "-optl-Wl,--export-dynamic"
-    ghc-options: "-optc-fvisibility=default"
-    ghc-options: "-optc-fvisibility-inlines-hidden"
-    flags: -tables-next-to-code
 
--- Maybe we should fix this with some import
-if os(linux)
-  package rts
-    ghc-options: "-optc-DProjectVersion=\"913\""
-    ghc-options: "-optc-DHostPlatform=\"x86_64-unknown-linux\""
-    ghc-options: "-optc-DHostArch=\"x86_64\""
-    ghc-options: "-optc-DHostOS=\"linux\""
-    ghc-options: "-optc-DHostVendor=\"unknown\""
-    ghc-options: "-optc-DBuildPlatform=\"FIXME\""
-    ghc-options: "-optc-DBuildArch=\"FIXME\""
-    ghc-options: "-optc-DBuildOS=\"FIXME\""
-    ghc-options: "-optc-DBuildVendor=\"FIXME\""
-    ghc-options: "-optc-DGhcUnregisterised=\"FIXME\""
-    ghc-options: "-optc-DTablesNextToCode=\"FIXME\""
-    ghc-options: "-optc-DFS_NAMESPACE=rts"
-    flags: +tables-next-to-code
-
-if os(darwin)
-  package rts
-    ghc-options: "-optc-DProjectVersion=\"913\""
-    ghc-options: "-optc-DHostPlatform=\"aarch64-apple-darwin\""
-    ghc-options: "-optc-DHostArch=\"aarch64\""
-    ghc-options: "-optc-DHostOS=\"darwin\""
-    ghc-options: "-optc-DHostVendor=\"unknown\""
-    ghc-options: "-optc-DBuildPlatform=\"FIXME\""
-    ghc-options: "-optc-DBuildArch=\"FIXME\""
-    ghc-options: "-optc-DBuildOS=\"FIXME\""
-    ghc-options: "-optc-DBuildVendor=\"FIXME\""
-    ghc-options: "-optc-DGhcUnregisterised=\"FIXME\""
-    ghc-options: "-optc-DTablesNextToCode=\"FIXME\""
-    ghc-options: "-optc-DFS_NAMESPACE=rts"
-    flags: +tables-next-to-code +leading-underscore
-
-if os(freebsd)
-  package rts
-    ghc-options: "-optc-DProjectVersion=\"914\""
-    ghc-options: "-optc-DHostPlatform=\"x86_64-portbld-freebsd\""
-    ghc-options: "-optc-DHostArch=\"x86_64\""
-    ghc-options: "-optc-DHostOS=\"freebsd\""
-    ghc-options: "-optc-DHostVendor=\"unknown\""
-    ghc-options: "-optc-DBuildPlatform=\"FIXME\""
-    ghc-options: "-optc-DBuildArch=\"FIXME\""
-    ghc-options: "-optc-DBuildOS=\"FIXME\""
-    ghc-options: "-optc-DBuildVendor=\"FIXME\""
-    ghc-options: "-optc-DGhcUnregisterised=\"FIXME\""
-    ghc-options: "-optc-DTablesNextToCode=\"FIXME\""
-    ghc-options: "-optc-DFS_NAMESPACE=rts"
-    flags: +tables-next-to-code
-
-program-options
-  ghc-options: -fhide-source-paths -j
-
--- project-boot-libs
-benchmarks: False
-tests: False
-allow-boot-library-installs: True
-active-repositories: :none
-
-package rts-headers
-  ghc-options: -no-rts
-
-package rts-fs
-  ghc-options: -no-rts
-
-package rts
-  ghc-options: -no-rts
+import: cabal.project.rts
 
 package libffi-clib
   ghc-options: -no-rts
@@ -226,15 +163,13 @@ package ghc-internal
 package text
   flags: -simdutf
 
-program-options
-  ghc-options: -fhide-source-paths -j
-
--- project-ghc
-benchmarks: False
-tests: False
-
+-- TODO: What is this? Why do we need _in-ghc-tree_ here?
 package hsc2hs
   flags: +in-ghc-tree
+
+--
+-- Program options
+--
 
 program-options
   ghc-options: -fhide-source-paths -j


### PR DESCRIPTION
- Improve the consistency across the stage cabal.project files by using the same ordering and delimiter comments
- "package-dbs: clear, global" is the default so it's removed