### PR TITLE
build(stage1): replace submodules with Hackage packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,12 +208,13 @@ CONFIGURED_FILES := \
 # --- Main Targets ---
 all: _build/bindist # booted will depend on prepare-sources
 
+# Note: for some reason hsc2hs:exe:hsc2hs or hsc2:hsc2hs do not work
 STAGE_UTIL_TARGETS := \
 	deriveConstants:deriveConstants \
 	genapply:genapply \
 	genprimopcode:genprimopcode \
 	ghc-pkg:ghc-pkg \
-	hsc2hs:hsc2hs \
+	hsc2hs \
 	rts-headers:rts-headers \
 	unlit:unlit
 

--- a/cabal.project.stage1
+++ b/cabal.project.stage1
@@ -13,24 +13,14 @@ packages:
   -- other packages.
   ghc
   compiler
-  libraries/directory
-  libraries/file-io
-  libraries/filepath
   libraries/ghc-platform
   libraries/ghc-boot
   libraries/ghc-boot-th-next
   libraries/ghc-heap
   libraries/ghci
-  libraries/os-string
-  libraries/process
-  libraries/semaphore-compat
---  libraries/time
-  libraries/unix
-  libraries/Win32
   libraries/Cabal/Cabal-syntax
   libraries/Cabal/Cabal
   utils/ghc-pkg
-  utils/hsc2hs
   utils/unlit
   utils/genprimopcode
   utils/genapply
@@ -38,6 +28,7 @@ packages:
   utils/ghc-toolchain
   utils/ghc-toolchain/exe
 
+extra-packages: hsc2hs
 
 benchmarks: False
 tests: False


### PR DESCRIPTION
- [fix handling of index-state](https://github.com/stable-haskell/ghc/commit/fb40549781e0ebe8100f29d56a6bef7e3cbaa6a7)

- [build(stage1): replace submodules with Hackage packages](https://github.com/stable-haskell/ghc/commit/944c889e125d9dc1eeb7ee518c9fa63d6adaec53)
  
  - Move hsc2hs from local utils directory to external Hackage dependency via extra-packages
  - Remove local package references for directory, file-io, filepath, os-string, process, semaphore-compat, unix, and Win32 libraries to use Hackage versions instead
  - Update Makefile to use bare hsc2hs target reference instead of fully qualified hsc2hs:hsc2hs
  - Add clarifying comment about hsc2hs target naming convention