### PR TITLE
gitignore: add AI coding assistant configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,31 @@ ghc.nix/
 # clangd
 .clangd
 dist-newstyle/
+
+# -----------------------------------------------------------------------------
+# AI Coding Assistants
+# See: https://agents.md/ for the AGENTS.md standard
+
+# Claude Code
+CLAUDE.md
+.claude
+
+# GitHub Copilot
+AGENTS.md
+AGENT.md
+.github/copilot-instructions.md
+.github/instructions/
+
+# Cursor
+.cursorrules
+.cursor/
+
+# Gemini CLI / Google Jules
+GEMINI.md
+JULES.md
+
+# OpenAI Codex
+CODEX.md
+
+# JetBrains Junie
+.aiignore


### PR DESCRIPTION
Add entries to prevent AI agent config files from being accidentally committed. These files contain project-specific instructions for various AI coding assistants and should remain local.

Covers: Claude Code, GitHub Copilot, Cursor, Gemini CLI/Jules, OpenAI Codex, and JetBrains Junie.

See: https://agents.md/ for the AGENTS.md standard