### PR TITLE
feat: Add timing and QUIET mode to Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,18 @@ jobs:
     #   shell: devx {0}
     #   run: ./configure
 
+    - name: Start metrics collection
+      shell: devx {0}
+      run: ./mk/collect-metrics.sh start _build/metrics 0.5
+
     - name: Build (dynamic=${{ matrix.dynamic }})
       shell: devx {0}
-      run: make DYNAMIC=${{ matrix.dynamic }}
+      run: make QUIET=1 DYNAMIC=${{ matrix.dynamic }}
+
+    - name: Display build timings
+      if: ${{ !cancelled() }}
+      shell: devx {0}
+      run: make timing-summary
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -75,16 +84,132 @@ jobs:
         name: ${{ matrix.plat }}-dynamic${{ matrix.dynamic }}-dist
         path: _build/dist
 
+    - name: Upload build logs and timing
+      uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: ${{ matrix.plat }}-dynamic${{ matrix.dynamic }}-build-logs
+        path: |
+          _build/logs/
+          _build/timing/
+
     - name: Run the testsuite (dynamic=${{ matrix.dynamic }})
       shell: devx {0}
-      run: make test DYNAMIC=${{ matrix.dynamic }}
+      run: make test QUIET=1 DYNAMIC=${{ matrix.dynamic }}
+
+    - name: Stop metrics collection
+      if: ${{ !cancelled() }}
+      shell: devx {0}
+      run: ./mk/collect-metrics.sh stop _build/metrics
+
+    - name: Display test timings
+      if: ${{ !cancelled() }}
+      shell: devx {0}
+      run: make timing-summary
+
+    - name: Generate metrics plots
+      if: ${{ !cancelled() }}
+      continue-on-error: true
+      shell: devx {0}
+      run: |
+        # Generate separate build and test SVG plots
+        nix-shell -p 'python3.withPackages (ps: [ps.matplotlib])' --run 'python3 ./mk/plot-metrics.py _build/metrics _build/timing _build/metrics/metrics'
+
+    - name: Upload metrics plots to R2
+      if: ${{ !cancelled() }}
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_METRICS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_METRICS_SECRET_ACCESS_KEY }}
+        R2_ENDPOINT: ${{ secrets.R2_METRICS_ENDPOINT }}
+        R2_PUBLIC_URL: ${{ vars.R2_METRICS_PUBLIC_URL }}
+        R2_BUCKET: ${{ vars.R2_METRICS_BUCKET_NAME }}
+      shell: devx {0}
+      run: |
+        RUN_ID="${{ github.run_id }}"
+        PLAT="${{ matrix.plat }}"
+        DYN="${{ matrix.dynamic }}"
+
+        export AWS_ENDPOINT_URL="${R2_ENDPOINT}"
+        export AWS_DEFAULT_REGION=auto
+
+        # Upload build plot if it exists
+        if [[ -f "_build/metrics/metrics-build.svg" ]]; then
+          BUILD_PATH="runs/${RUN_ID}/${PLAT}-dynamic${DYN}-build.svg"
+          nix-shell --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_ENDPOINT_URL --keep AWS_DEFAULT_REGION -p awscli2 --run "aws s3 cp _build/metrics/metrics-build.svg s3://${R2_BUCKET}/${BUILD_PATH} --content-type 'image/svg+xml'" || echo "Failed to upload build plot (non-fatal)"
+          echo "BUILD_PLOT_URL=${R2_PUBLIC_URL}/${BUILD_PATH}" >> $GITHUB_ENV
+        fi
+
+        # Upload test plot if it exists
+        if [[ -f "_build/metrics/metrics-test.svg" ]]; then
+          TEST_PATH="runs/${RUN_ID}/${PLAT}-dynamic${DYN}-test.svg"
+          nix-shell --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_ENDPOINT_URL --keep AWS_DEFAULT_REGION -p awscli2 --run "aws s3 cp _build/metrics/metrics-test.svg s3://${R2_BUCKET}/${TEST_PATH} --content-type 'image/svg+xml'" || echo "Failed to upload test plot (non-fatal)"
+          echo "TEST_PLOT_URL=${R2_PUBLIC_URL}/${TEST_PATH}" >> $GITHUB_ENV
+        fi
+
+    - name: Write metrics summary
+      if: ${{ !cancelled() }}
+      shell: devx {0}
+      run: |
+        echo "## Build Metrics Summary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+
+        # Embed build plot if available
+        if [[ -n "${BUILD_PLOT_URL:-}" ]]; then
+          echo "### Build Phases (CPU & Memory)" >> $GITHUB_STEP_SUMMARY
+          echo "<img src=\"${BUILD_PLOT_URL}\" alt=\"Build Metrics\" width=\"100%\">" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        # Embed test plot if available
+        if [[ -n "${TEST_PLOT_URL:-}" ]]; then
+          echo "### Test Phase (CPU & Memory)" >> $GITHUB_STEP_SUMMARY
+          echo "<img src=\"${TEST_PLOT_URL}\" alt=\"Test Metrics\" width=\"100%\">" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        echo "### Phase Timings" >> $GITHUB_STEP_SUMMARY
+        echo "| Phase | Duration | Status |" >> $GITHUB_STEP_SUMMARY
+        echo "|-------|----------|--------|" >> $GITHUB_STEP_SUMMARY
+
+        # Auto-discover phases from timing files (summary.txt is generated
+        # by timing-summary.sh with ordered top-level + sub-phases)
+        make timing-summary 2>/dev/null || true
+        if [[ -f "_build/timing/summary.txt" ]]; then
+          while read -r phase dur status; do
+            mins=$((dur / 60))
+            secs=$((dur % 60))
+            status_str="OK"
+            [[ "$status" == "1" ]] && status_str="FAIL"
+            # Indent sub-phases (contain a dot) with leading spaces
+            if [[ "$phase" == *.* ]]; then
+              echo "| &nbsp;&nbsp;$phase | ${mins}m ${secs}s | $status_str |" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "| **$phase** | **${mins}m ${secs}s** | $status_str |" >> $GITHUB_STEP_SUMMARY
+            fi
+          done < "_build/timing/summary.txt"
+        fi
+        echo "" >> $GITHUB_STEP_SUMMARY
+        # Add memory stats from metrics
+        if [[ -f "_build/metrics/metrics.csv" ]]; then
+          max_mem=$(awk -F',' 'NR>1 {if($3>max) max=$3} END {printf "%.1f", max/1024}' _build/metrics/metrics.csv)
+          echo "**Peak Memory:** ${max_mem} GB" >> $GITHUB_STEP_SUMMARY
+        fi
 
     - name: Upload test results
       uses: actions/upload-artifact@v4
-      if: ${{ !cancelled() }} # upload test results even if the testsuite failed to pass
+      if: ${{ !cancelled() }}
       with:
         name: ${{ matrix.plat }}-dynamic${{ matrix.dynamic }}-testsuite-results
         path: |
           _build/test-perf.csv
           _build/test-summary.txt
           _build/test-junit.xml
+          _build/timing/
+
+    - name: Upload metrics
+      uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: ${{ matrix.plat }}-dynamic${{ matrix.dynamic }}-metrics
+        path: |
+          _build/metrics/

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@
 
 SHELL := bash
 .SHELLFLAGS := -eu -o pipefail -c
+.DEFAULT_GOAL := all
 
 VERBOSE ?= 0
 
@@ -95,6 +96,13 @@ UNAME := $(shell uname)
 # -DDYNAMIC) and allow tests requiring dynamic linking (e.g. plugins-external)
 # to run. The default remains static to keep rebuild cost low.
 DYNAMIC ?= 0
+
+# Quiet mode: suppress output unless error (QUIET=1)
+QUIET ?= 0
+
+# Metrics collection: start background CPU/memory sampling (METRICS=1)
+METRICS ?= 0
+METRICS_INTERVAL ?= 0.5
 
 #
 # System tools
@@ -157,6 +165,12 @@ STORE_DIR   = $(STAGE_DIR)/store
 LOGS_DIR    = $(STAGE_DIR)/logs
 
 DIST_DIR   := $(BUILD_DIR)/dist
+
+# Timing directory for phase start/end timestamps
+TIMING_DIR := $(BUILD_DIR)/timing
+
+# Metrics directory for CPU/memory CSV data
+METRICS_DIR := $(BUILD_DIR)/metrics
 
 # HOST_PLATFROM is always from the bootstrap compiler
 HOST_PLATFORM := $(shell $(GHC0) --print-host-platform)
@@ -221,6 +235,28 @@ LOG_GROUP_START = @echo "$(BOLD)>>>>> $1$(NORMAL)"
 LOG_GROUP_END = @echo ""
 
 LOG = @echo "$(BOLD)[$(STAGE)]$(NORMAL): $(1)"
+
+ifeq ($(QUIET),1)
+LOG = @:
+LOG_GROUP_START = @:
+LOG_GROUP_END = @:
+endif
+
+# Phase timing: records start/end timestamps and status
+define PHASE_START
+	@mkdir -p $(TIMING_DIR)
+	@date +%s > $(TIMING_DIR)/$(1).start
+endef
+
+define PHASE_END_OK
+	@date +%s > $(TIMING_DIR)/$(1).end
+	@echo "0" > $(TIMING_DIR)/$(1).status
+endef
+
+define PHASE_END_FAIL
+	@date +%s > $(TIMING_DIR)/$(1).end
+	@echo "1" > $(TIMING_DIR)/$(1).status
+endef
 
 define NORMALIZE_FP
 $(shell echo $(1) | $(CYGPATH_MIXED))
@@ -442,6 +478,24 @@ CONFIGURED_FILES := \
 # |_|  |_|\__,_|_|_| |_|  \__\__,_|_|  \__, |\___|\__|
 #                                      |___/
 
+.PHONY: timing-summary
+timing-summary:
+	@./mk/timing-summary.sh $(TIMING_DIR)
+
+.PHONY: metrics-start metrics-stop metrics-plot
+metrics-start:
+	@./mk/collect-metrics.sh start $(METRICS_DIR) $(METRICS_INTERVAL)
+
+metrics-stop:
+	@./mk/collect-metrics.sh stop $(METRICS_DIR)
+
+metrics-plot:
+	@if [ -f "$(METRICS_DIR)/metrics.csv" ]; then \
+		$(PYTHON) ./mk/plot-metrics.py $(METRICS_DIR) $(TIMING_DIR) $(METRICS_DIR)/metrics; \
+	else \
+		echo "No metrics data found. Run 'make METRICS=1 all' first."; \
+	fi
+
 .PHONY: all
 all: stage2
 
@@ -454,10 +508,12 @@ all: stage2
 .PHONY: $(CABAL)
 $(CABAL): STAGE=stage0
 $(CABAL):
+	$(call PHASE_START,cabal)
 	$(call LOG,Building $@)
 	$(CABAL_BUILD_STAGE0) --with-compiler $(GHC0) cabal-install:exe:cabal
 	@mkdir -p $(@D)
 	@cp $$($(CABAL0) list-bin -v0 -j --with-compiler $(GHC0) --project-file=cabal.project.stage0 --builddir=$(CURDIR)/$(STAGE_DIR) cabal-install:exe:cabal | $(CYGPATH)) $@
+	$(call PHASE_END_OK,cabal)
 
 stage0 : $(CABAL)
 
@@ -498,10 +554,13 @@ STAGE1_CABAL_BUILD = \
 
 stage1: STAGE=stage1
 stage1: $(CABAL) $(CONFIGURE_SCRIPTS) $(CONFIGURED_FILES) cabal.project.stage1 cabal.project.common libraries/ghc-boot-th-next | hackage
+	$(call PHASE_START,stage1)
 	$(call LOG,Starting build of $(STAGE))
 
+	$(call PHASE_START,stage1.executables)
 	$(call LOG,Building executables $(STAGE1_EXECUTABLES))
 	$(STAGE1_CABAL_BUILD) $(addprefix exe:,$(STAGE1_EXECUTABLES))
+	$(call PHASE_END_OK,stage1.executables)
 
 	$(call LOG,Creating $(STORE_DIR)/host/$(HOST_PLATFORM)/lib/settings)
 	@$(STORE_DIR)/host/$(HOST_PLATFORM)/bin/ghc-toolchain-bin $(GHC_TOOLCHAIN_ARGS) --triple $(HOST_PLATFORM) --cc $(CC) --cxx $(CXX) --cc-link-opt "$(CC_LINK_OPT)" --output-settings -o $(STORE_DIR)/host/$(HOST_PLATFORM)/lib/settings
@@ -514,6 +573,7 @@ endif
 	@$(STORE_DIR)/host/$(HOST_PLATFORM)/bin/ghc-pkg init $(STORE_DIR)/host/$(HOST_PLATFORM)/lib/package.conf.d
 
 	$(call LOG,Finished building $(STAGE))
+	$(call PHASE_END_OK,stage1)
 
 $(addprefix $(STAGE1_PATH)/bin/,$(STAGE1_EXECUTABLES)) : stage1
 
@@ -614,17 +674,25 @@ STAGE2_CABAL_BUILD = \
 stage2: STAGE=stage2
 stage2: TARGET_PLATFORM:=$(HOST_PLATFORM)
 stage2: $(GHC1) $(CABAL) $(CONFIGURE_SCRIPTS) $(CONFIGURED_FILES) cabal.project.stage2 cabal.project.stage2.settings cabal.project.common libraries/ghc-boot-th-next | stage1
+	$(call PHASE_START,stage2)
 	$(call LOG,Starting build of $(STAGE))
 
+	$(call PHASE_START,stage2.rts)
 	$(call LOG,Building rts)
 	$(STAGE2_CABAL_BUILD) rts
+	$(call PHASE_END_OK,stage2.rts)
 
+	$(call PHASE_START,stage2.executables)
 	$(call LOG,Building executables $(STAGE2_EXECUTABLES))
 	$(STAGE2_CABAL_BUILD) $(addprefix exe:,$(STAGE2_EXECUTABLES))
+	$(call PHASE_END_OK,stage2.executables)
 
+	$(call PHASE_START,stage2.libraries)
 	$(call LOG,Building libraries $(filter-out rts%,$(STAGE2_LIBRARIES)))
 	$(STAGE2_CABAL_BUILD) $(filter-out rts%,$(STAGE2_LIBRARIES))
+	$(call PHASE_END_OK,stage2.libraries)
 
+	$(call PHASE_START,stage2.dist)
 	$(call LOG,Building distribution in $(DIST_DIR))
 	@rm -rf $(DIST_DIR)
 
@@ -666,6 +734,8 @@ endif
 	@cp -rfp driver/ghci-usage.txt $(DIST_DIR)/lib/
 
 	$(call LOG,Finished building $(STAGE) in $(DIST_DIR))
+	$(call PHASE_END_OK,stage2.dist)
+	$(call PHASE_END_OK,stage2)
 
 $(addprefix $(STAGE2_PATH)/bin/,$(STAGE2_EXECUTABLES)) : stage2
 
@@ -799,6 +869,7 @@ STAGE3_$(1)_CABAL_BUILD = \
 stage3-$(1): STAGE=stage3
 stage3-$(1): TARGET_PLATFORM=$(1)
 stage3-$(1): $(GHC2) $$(STAGE1_PATH)/bin/ghc-toolchain-bin $(CONFIGURE_SCRIPTS) $(CONFIGURED_FILES) libraries/ghc-boot-th-next cabal.project.common cabal.project.stage3 stage3-$(1)-additional-files
+	$$(call PHASE_START,stage3-$(1))
 	$$(call LOG,Linking executables)
 	$$(foreach exe,$$(STAGE3_EXECUTABLES),$(LN_SF) $$(exe) $(DIST_DIR)/bin/$(1)-$$(exe);)
 
@@ -823,12 +894,17 @@ stage3-$(1): $(GHC2) $$(STAGE1_PATH)/bin/ghc-toolchain-bin $(CONFIGURE_SCRIPTS) 
 	@rm -rf $$(TARGET_DIR)/lib/package.conf.d
 	$$(DIST_DIR)/bin/$(1)-ghc-pkg init $$(TARGET_DIR)/lib/package.conf.d
 
+	$$(call PHASE_START,stage3-$(1).rts)
 	$$(call LOG,Building library rts:nonthreaded-nodebug)
 	$$(STAGE3_$(1)_CABAL_BUILD) rts:nonthreaded-nodebug
+	$$(call PHASE_END_OK,stage3-$(1).rts)
 
+	$$(call PHASE_START,stage3-$(1).libraries)
 	$$(call LOG,Building libraries $(STAGE3_LIBRARIES))
 	$$(STAGE3_$(1)_CABAL_BUILD) $(filter-out rts%,$(STAGE3_LIBRARIES))
+	$$(call PHASE_END_OK,stage3-$(1).libraries)
 
+	$$(call PHASE_START,stage3-$(1).dist)
 	$$(call LOG,Copying libraries into distribution for target $(1))
 	@mkdir -p $$(TARGET_DIR)/lib/package.conf.d
 	@mkdir -p $$(TARGET_DIR)/lib/$(1)
@@ -845,6 +921,8 @@ stage3-$(1): $(GHC2) $$(STAGE1_PATH)/bin/ghc-toolchain-bin $(CONFIGURE_SCRIPTS) 
 	$$(call LOG,Copying ghc-usage files)
 	@cp -rfp driver/ghc-usage.txt $$(TARGET_DIR)/lib/
 	@cp -rfp driver/ghci-usage.txt $$(TARGET_DIR)/lib/
+	$$(call PHASE_END_OK,stage3-$(1).dist)
+	$$(call PHASE_END_OK,stage3-$(1))
 
 $(DIST_DIR)/ghc-$(1).tar.gz: stage3-$(1)
 	@echo "::group::Creating ghc-$(1).tar.gz..."
@@ -1068,6 +1146,7 @@ testsuite-timeout:
 # --- Test Target ---
 
 test: stage2 testsuite-timeout
+	$(call PHASE_START,test)
 	@echo "::group::Running tests with THREADS=$(THREADS)" >&2
 	# If any required tool is missing, testsuite logic will skip related tests.
 	TEST_HC='$(TEST_GHC)' \
@@ -1085,6 +1164,7 @@ test: stage2 testsuite-timeout
 	THREADS='$(THREADS)' \
 	$(MAKE) -C testsuite/tests test
 	@echo "::endgroup::"
+	$(call PHASE_END_OK,test)
 
 # Inform Make that these are not actual files if they get deleted by other means
 .PHONY: clean clean-stage1 clean-stage2 clean-stage3 distclean test

--- a/mk/collect-metrics.sh
+++ b/mk/collect-metrics.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# collect-metrics.sh - Collect CPU and memory metrics during build
+#
+# Usage: collect-metrics.sh start METRICS_DIR [INTERVAL]
+#        collect-metrics.sh stop
+#
+# Commands:
+#   start   - Start collecting metrics (runs in background)
+#   stop    - Stop metrics collection
+#
+# Arguments:
+#   METRICS_DIR - Directory for metrics output
+#   INTERVAL    - Sample interval in seconds (default: 0.5)
+#
+# Output files:
+#   $METRICS_DIR/metrics.csv  - CSV with timestamp, cpu%, mem_used_mb, mem_total_mb
+#   $METRICS_DIR/collector.pid - PID file for the collector process
+
+set -uo pipefail
+
+CMD="${1:-}"
+METRICS_DIR="${2:-_build/metrics}"
+INTERVAL="${3:-0.5}"
+
+PID_FILE="$METRICS_DIR/collector.pid"
+METRICS_FILE="$METRICS_DIR/metrics.csv"
+
+# Detect OS for platform-specific commands
+OS="$(uname -s)"
+
+# State file for CPU delta calculation
+CPU_STATE_FILE=""
+
+# Get CPU usage percentage (cross-platform)
+# Calculates delta between samples for accurate instantaneous usage
+get_cpu_usage() {
+    case "$OS" in
+        Darwin)
+            # macOS: use sysctl for instant CPU ticks, calculate delta
+            # This is much faster than top or iostat
+            local ticks
+            ticks=$(sysctl -n kern.cp_time 2>/dev/null)
+            if [[ -z "$ticks" ]]; then
+                # Fallback: use ps to get total CPU (less accurate but fast)
+                ps -A -o %cpu | awk '{sum += $1} END {printf "%.1f", sum}'
+                return
+            fi
+
+            # Parse: user nice sys idle
+            local user nice sys idle total
+            read user nice sys idle <<< "$ticks"
+            total=$((user + nice + sys + idle))
+
+            # Calculate delta from previous sample
+            if [[ -f "$CPU_STATE_FILE" ]]; then
+                local prev_total prev_idle
+                read prev_total prev_idle < "$CPU_STATE_FILE"
+                local delta_total=$((total - prev_total))
+                local delta_idle=$((idle - prev_idle))
+                if [[ $delta_total -gt 0 ]]; then
+                    echo "$total $idle" > "$CPU_STATE_FILE"
+                    awk "BEGIN {printf \"%.1f\", 100 * (1 - $delta_idle / $delta_total)}"
+                    return
+                fi
+            fi
+
+            # First sample or invalid delta: store state, return cumulative
+            echo "$total $idle" > "$CPU_STATE_FILE"
+            if [[ $total -gt 0 ]]; then
+                awk "BEGIN {printf \"%.1f\", 100 * (1 - $idle / $total)}"
+            else
+                echo "0"
+            fi
+            ;;
+        Linux)
+            # Linux: calculate from /proc/stat with delta
+            # /proc/stat format: cpu  <user> <nice> <system> <idle> <iowait> <irq> <softirq> [steal] [guest] [guest_nice]
+            if [[ ! -f /proc/stat ]]; then
+                echo "0"
+                return
+            fi
+
+            local line
+            read -r line < /proc/stat
+
+            # Parse fields - use named variable for label instead of _ (special bash variable)
+            # Note: /proc/stat has 10 numeric fields; we only need the first 7 for CPU calculation
+            # The 'rest' variable captures any additional fields (steal, guest, guest_nice)
+            local label user nice sys idle iowait irq softirq rest
+            read label user nice sys idle iowait irq softirq rest <<< "$line"
+
+            # Validate we got numeric values (guards against parse failures)
+            if [[ -z "$user" || -z "$idle" ]]; then
+                echo "0"
+                return
+            fi
+
+            local total=$((user + nice + sys + idle + iowait + irq + softirq))
+
+            if [[ -f "$CPU_STATE_FILE" ]]; then
+                local prev_total prev_idle
+                read prev_total prev_idle < "$CPU_STATE_FILE"
+                local delta_total=$((total - prev_total))
+                local delta_idle=$((idle - prev_idle))
+                if [[ $delta_total -gt 0 ]]; then
+                    echo "$total $idle" > "$CPU_STATE_FILE"
+                    awk "BEGIN {printf \"%.1f\", 100 * (1 - $delta_idle / $delta_total)}"
+                    return
+                fi
+            fi
+
+            echo "$total $idle" > "$CPU_STATE_FILE"
+            if [[ $total -gt 0 ]]; then
+                awk "BEGIN {printf \"%.1f\", 100 * (1 - $idle / $total)}"
+            else
+                echo "0"
+            fi
+            ;;
+        *)
+            echo "0"
+            ;;
+    esac
+}
+
+# Get memory usage in MB (cross-platform)
+get_memory_usage() {
+    case "$OS" in
+        Darwin)
+            # macOS: use vm_stat and sysctl
+            page_size=$(sysctl -n hw.pagesize 2>/dev/null || echo 4096)
+            total_mb=$(( $(sysctl -n hw.memsize 2>/dev/null || echo 0) / 1024 / 1024 ))
+
+            # Parse vm_stat output
+            vm_stat 2>/dev/null | awk -v ps="$page_size" -v total="$total_mb" '
+                /Pages active/ { active = $3 + 0 }
+                /Pages wired/ { wired = $4 + 0 }
+                /Pages compressed/ { compressed = $5 + 0 }
+                END {
+                    used_mb = int((active + wired + compressed) * ps / 1024 / 1024)
+                    printf "%d,%d", used_mb, total
+                }
+            '
+            ;;
+        Linux)
+            # Linux: parse /proc/meminfo
+            awk '
+                /^MemTotal:/ { total = $2 }
+                /^MemAvailable:/ { available = $2 }
+                END {
+                    total_mb = int(total / 1024)
+                    used_mb = int((total - available) / 1024)
+                    printf "%d,%d", used_mb, total_mb
+                }
+            ' /proc/meminfo
+            ;;
+        *)
+            echo "0,0"
+            ;;
+    esac
+}
+
+# Collector loop
+run_collector() {
+    mkdir -p "$METRICS_DIR"
+
+    # Initialize CPU state file for delta calculations
+    CPU_STATE_FILE="$METRICS_DIR/.cpu_state"
+    rm -f "$CPU_STATE_FILE"
+
+    # Write CSV header
+    echo "timestamp,cpu_percent,mem_used_mb,mem_total_mb" > "$METRICS_FILE"
+
+    while true; do
+        timestamp=$(date +%s)
+        cpu=$(get_cpu_usage)
+        mem=$(get_memory_usage)
+
+        echo "$timestamp,$cpu,$mem" >> "$METRICS_FILE"
+        sleep "$INTERVAL"
+    done
+}
+
+case "$CMD" in
+    start)
+        mkdir -p "$METRICS_DIR"
+
+        # Stop any existing collector
+        if [[ -f "$PID_FILE" ]]; then
+            old_pid=$(cat "$PID_FILE")
+            kill "$old_pid" 2>/dev/null || true
+            rm -f "$PID_FILE"
+        fi
+
+        # Start collector in background
+        run_collector &
+        collector_pid=$!
+        echo "$collector_pid" > "$PID_FILE"
+        echo "Started metrics collector (PID: $collector_pid, interval: ${INTERVAL}s)"
+        echo "Output: $METRICS_FILE"
+        ;;
+
+    stop)
+        if [[ -f "$PID_FILE" ]]; then
+            pid=$(cat "$PID_FILE")
+            if kill "$pid" 2>/dev/null; then
+                echo "Stopped metrics collector (PID: $pid)"
+            else
+                echo "Collector process $pid not running"
+            fi
+            rm -f "$PID_FILE"
+        else
+            echo "No collector PID file found"
+        fi
+        ;;
+
+    *)
+        echo "Usage: $0 start METRICS_DIR [INTERVAL]"
+        echo "       $0 stop"
+        exit 1
+        ;;
+esac

--- a/mk/plot-metrics.py
+++ b/mk/plot-metrics.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""
+plot-metrics.py - Generate build metrics visualization
+
+Usage: plot-metrics.py METRICS_DIR TIMING_DIR [OUTPUT_PREFIX]
+
+Arguments:
+    METRICS_DIR   - Directory containing metrics.csv
+    TIMING_DIR    - Directory containing phase timing files (.start, .end)
+    OUTPUT_PREFIX - Output file prefix (default: METRICS_DIR/build-metrics)
+                    Generates: PREFIX-build.svg and PREFIX-test.svg
+
+Creates dual-axis plots showing:
+    - CPU usage over time (left axis, blue)
+    - Memory usage over time (right axis, green)
+    - Phase markers with shaded regions and labels
+
+Two separate plots are generated:
+    - Build plot: cabal, stage1, stage2, stage2-utils, bindist phases
+    - Test plot: test phase only
+"""
+
+import sys
+import os
+import csv
+import hashlib
+from datetime import datetime
+from pathlib import Path
+
+# Try to import matplotlib, provide helpful error if not available
+try:
+    import matplotlib
+    matplotlib.use('Agg')  # Non-interactive backend for headless use
+    import matplotlib.pyplot as plt
+    import matplotlib.dates as mdates
+    from matplotlib.patches import Rectangle
+except ImportError:
+    print("Error: matplotlib is required. Install with:")
+    print("  nix run nixpkgs#python3Packages.matplotlib -- mk/plot-metrics.py ...")
+    print("  # or: pip install matplotlib")
+    sys.exit(1)
+
+
+def read_metrics(metrics_file):
+    """Read metrics CSV file and return timestamps, cpu, and memory data."""
+    timestamps = []
+    cpu_percent = []
+    mem_used_mb = []
+    mem_total_mb = []
+
+    with open(metrics_file, 'r') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                ts = int(row['timestamp'])
+                timestamps.append(datetime.fromtimestamp(ts))
+                cpu_percent.append(float(row['cpu_percent']))
+                mem_used_mb.append(float(row['mem_used_mb']))
+                mem_total_mb.append(float(row['mem_total_mb']))
+            except (ValueError, KeyError) as e:
+                continue  # Skip malformed rows
+
+    return timestamps, cpu_percent, mem_used_mb, mem_total_mb
+
+
+def read_phases(timing_dir):
+    """Read phase timing files and return list of (name, start_time, end_time, status)."""
+    phases = []
+    timing_path = Path(timing_dir)
+
+    # Find all .start files
+    for start_file in timing_path.glob('*.start'):
+        phase_name = start_file.stem
+        end_file = timing_path / f"{phase_name}.end"
+        status_file = timing_path / f"{phase_name}.status"
+
+        if not end_file.exists():
+            continue
+
+        try:
+            with open(start_file) as f:
+                start_ts = int(f.read().strip())
+            with open(end_file) as f:
+                end_ts = int(f.read().strip())
+
+            status = "OK"
+            if status_file.exists():
+                with open(status_file) as f:
+                    status = "FAIL" if f.read().strip() == "1" else "OK"
+
+            phases.append((
+                phase_name,
+                datetime.fromtimestamp(start_ts),
+                datetime.fromtimestamp(end_ts),
+                status
+            ))
+        except (ValueError, IOError):
+            continue
+
+    # Sort by start time
+    phases.sort(key=lambda x: x[1])
+    return phases
+
+
+def format_duration(seconds):
+    """Format duration in human-readable form."""
+    if seconds < 60:
+        return f"{seconds}s"
+    elif seconds < 3600:
+        mins = seconds // 60
+        secs = seconds % 60
+        return f"{mins}m {secs}s"
+    else:
+        hours = seconds // 3600
+        mins = (seconds % 3600) // 60
+        return f"{hours}h {mins}m"
+
+
+def create_plot(timestamps, cpu, mem_used, mem_total, phases, title, output_file):
+    """Create a single metrics plot for the given data and phases."""
+    # Define colors
+    cpu_color = '#2E86AB'      # Blue
+    mem_color = '#28A745'      # Green
+    phase_colors = {
+        'cabal': '#FFD700',        # Gold
+        'stage1': '#FF6B6B',       # Red
+        'stage2': '#4ECDC4',       # Teal
+        'test': '#DDA0DD',         # Plum
+    }
+    # stage3-* platforms get distinct colors
+    stage3_palette = ['#FF8C42', '#6A0572', '#1B998B', '#E55934']
+
+    # Create figure with dual y-axes - wider aspect ratio (20:6)
+    fig, ax1 = plt.subplots(figsize=(20, 6))
+
+    # Calculate effective concurrency from max CPU usage
+    max_cpu = max(cpu) if cpu else 100
+    effective_cores = int((max_cpu + 99) // 100)  # ceil(max_cpu / 100)
+    cpu_limit = effective_cores * 100
+
+    # Plot CPU usage
+    ax1.set_xlabel('Time', fontsize=11)
+    ax1.set_ylabel(f'CPU Usage (%, {effective_cores} cores)', color=cpu_color, fontsize=11)
+    line1, = ax1.plot(timestamps, cpu, color=cpu_color, linewidth=1.2, alpha=0.8, label='CPU %')
+    ax1.tick_params(axis='y', labelcolor=cpu_color)
+    ax1.set_ylim(0, cpu_limit * 1.05)
+    ax1.grid(True, alpha=0.3)
+
+    # Create second y-axis for memory
+    ax2 = ax1.twinx()
+    ax2.set_ylabel('Memory Used (GB)', color=mem_color, fontsize=11)
+    mem_gb = [m / 1024 for m in mem_used]
+    line2, = ax2.plot(timestamps, mem_gb, color=mem_color, linewidth=1.2, alpha=0.8, label='Memory (GB)')
+    ax2.tick_params(axis='y', labelcolor=mem_color)
+
+    # Set memory y-axis limit based on total memory
+    if mem_total:
+        max_mem_gb = max(mem_total) / 1024
+        ax2.set_ylim(0, max_mem_gb * 1.1)
+
+    # Add phase markers as shaded regions
+    if phases and timestamps:
+        plot_start = timestamps[0]
+        plot_end = timestamps[-1]
+
+        for phase_name, start, end, status in phases:
+            # Clamp to plot range
+            if end < plot_start or start > plot_end:
+                continue
+
+            start = max(start, plot_start)
+            end = min(end, plot_end)
+
+            # Get color for phase (stage3-* uses rotating palette)
+            if phase_name in phase_colors:
+                color = phase_colors[phase_name]
+            elif phase_name.startswith('stage3-'):
+                # Stable hash so the same platform always gets the same color
+                idx = int(hashlib.sha256(phase_name.encode()).hexdigest(), 16) % len(stage3_palette)
+                color = stage3_palette[idx]
+            else:
+                color = '#CCCCCC'
+
+            # Add shaded region
+            ax1.axvspan(start, end, alpha=0.2, color=color)
+
+            # Add vertical line at phase start
+            ax1.axvline(x=start, color=color, linestyle='--', linewidth=1, alpha=0.7)
+
+            # Add phase label at top
+            mid_time = start + (end - start) / 2
+            duration = int((end - start).total_seconds())
+            duration_str = format_duration(duration)
+            status_marker = '\u2713' if status == 'OK' else '\u2717'
+
+            ax1.annotate(
+                f'{phase_name}\n{duration_str} {status_marker}',
+                xy=(mid_time, cpu_limit),
+                fontsize=10,
+                ha='center',
+                va='top',
+                bbox=dict(boxstyle='round,pad=0.3', facecolor=color, alpha=0.7)
+            )
+
+    # Format x-axis
+    ax1.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M'))
+    ax1.xaxis.set_major_locator(mdates.AutoDateLocator())
+    plt.xticks(rotation=45)
+
+    # Title
+    plt.title(title, fontsize=13, fontweight='bold')
+
+    # Legend
+    lines = [line1, line2]
+    labels = ['CPU Usage (%)', 'Memory Used (GB)']
+    ax1.legend(lines, labels, loc='upper left', framealpha=0.9)
+
+    # Tight layout
+    plt.tight_layout()
+
+    # Save as SVG
+    plt.savefig(output_file, format='svg', bbox_inches='tight')
+    plt.close(fig)
+    print(f"Plot saved to: {output_file}")
+
+
+def filter_metrics_for_phases(timestamps, cpu, mem_used, mem_total, phases):
+    """Filter metrics data to only include time range covered by phases."""
+    if not phases or not timestamps:
+        return timestamps, cpu, mem_used, mem_total
+
+    # Get time range from phases
+    phase_start = min(p[1] for p in phases)
+    phase_end = max(p[2] for p in phases)
+
+    # Add some margin (30 seconds before and after)
+    from datetime import timedelta
+    margin = timedelta(seconds=30)
+    range_start = phase_start - margin
+    range_end = phase_end + margin
+
+    # Filter data
+    filtered = [(t, c, m, mt) for t, c, m, mt in zip(timestamps, cpu, mem_used, mem_total)
+                if range_start <= t <= range_end]
+
+    if not filtered:
+        return timestamps, cpu, mem_used, mem_total
+
+    return zip(*filtered)
+
+
+def plot_metrics(metrics_dir, timing_dir, output_prefix):
+    """Generate the metrics plots (build and test separately)."""
+    metrics_file = Path(metrics_dir) / 'metrics.csv'
+
+    if not metrics_file.exists():
+        print(f"Error: Metrics file not found: {metrics_file}")
+        sys.exit(1)
+
+    # Read data
+    timestamps, cpu, mem_used, mem_total = read_metrics(metrics_file)
+    all_phases = read_phases(timing_dir)
+
+    if not timestamps:
+        print("Error: No metrics data found")
+        sys.exit(1)
+
+    # Separate build phases from test phase.
+    # Include top-level phases only (no sub-phases with dots) to avoid clutter.
+    # stage3-* platforms are build phases.
+    def is_build_phase(name):
+        if '.' in name:
+            return False  # Skip sub-phases
+        return name in ('cabal', 'stage1', 'stage2') or name.startswith('stage3-')
+
+    build_phases = [p for p in all_phases if is_build_phase(p[0])]
+    test_phases = [p for p in all_phases if p[0] == 'test']
+
+    # Generate build plot
+    if build_phases:
+        ts_build, cpu_build, mem_build, mem_total_build = filter_metrics_for_phases(
+            timestamps, cpu, mem_used, mem_total, build_phases)
+        ts_build, cpu_build, mem_build, mem_total_build = list(ts_build), list(cpu_build), list(mem_build), list(mem_total_build)
+
+        build_duration = int((build_phases[-1][2] - build_phases[0][1]).total_seconds())
+        build_title = f'GHC Build Metrics - Total: {format_duration(build_duration)}'
+        build_output = f"{output_prefix}-build.svg"
+        create_plot(ts_build, cpu_build, mem_build, mem_total_build,
+                   build_phases, build_title, build_output)
+
+    # Generate test plot
+    if test_phases:
+        ts_test, cpu_test, mem_test, mem_total_test = filter_metrics_for_phases(
+            timestamps, cpu, mem_used, mem_total, test_phases)
+        ts_test, cpu_test, mem_test, mem_total_test = list(ts_test), list(cpu_test), list(mem_test), list(mem_total_test)
+
+        test_duration = int((test_phases[-1][2] - test_phases[0][1]).total_seconds())
+        test_title = f'GHC Test Metrics - Duration: {format_duration(test_duration)}'
+        test_output = f"{output_prefix}-test.svg"
+        create_plot(ts_test, cpu_test, mem_test, mem_total_test,
+                   test_phases, test_title, test_output)
+
+    # Print phase summary
+    if all_phases:
+        total_duration = int((all_phases[-1][2] - all_phases[0][1]).total_seconds())
+        print("\nPhase Summary:")
+        print("-" * 50)
+        for phase_name, start, end, status in all_phases:
+            duration = int((end - start).total_seconds())
+            print(f"  {phase_name:15} {format_duration(duration):>10}  [{status}]")
+        print("-" * 50)
+        print(f"  {'TOTAL':15} {format_duration(total_duration):>10}")
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(1)
+
+    metrics_dir = sys.argv[1]
+    timing_dir = sys.argv[2]
+    output_prefix = sys.argv[3] if len(sys.argv) > 3 else os.path.join(metrics_dir, 'metrics')
+
+    plot_metrics(metrics_dir, timing_dir, output_prefix)
+
+
+if __name__ == '__main__':
+    main()

--- a/mk/run-phase.sh
+++ b/mk/run-phase.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# run-phase.sh - Wrapper for timed build phases with quiet mode support
+#
+# Usage: run-phase.sh PHASE_NAME QUIET TIMING_DIR LOGS_DIR -- COMMAND...
+#
+# Arguments:
+#   PHASE_NAME  - Name of the build phase (cabal, stage1, stage2, bindist, test)
+#   QUIET       - "1" to suppress output (log to file), "0" for normal output
+#   TIMING_DIR  - Directory for timing files (.start, .end, .status)
+#   LOGS_DIR    - Directory for log files
+#   COMMAND...  - The actual build command to run
+#
+# Creates:
+#   $TIMING_DIR/$PHASE.start  - Unix timestamp when phase started
+#   $TIMING_DIR/$PHASE.end    - Unix timestamp when phase ended
+#   $TIMING_DIR/$PHASE.status - "0" for success, "1" for failure
+#   $LOGS_DIR/$PHASE.log      - Build output (only in quiet mode)
+#
+# On failure in quiet mode, prints last 100 lines of log.
+#
+# No-op detection:
+#   If a build completes in < 30s AND previous timing files exist with
+#   duration > 30s, the previous timing is preserved. This prevents
+#   "make test" from overwriting real build times with no-op verification times.
+
+set -uo pipefail
+
+PHASE="$1"
+QUIET="$2"
+TIMING_DIR="$3"
+LOGS_DIR="$4"
+shift 4
+
+# Consume the -- separator if present
+[[ "${1:-}" == "--" ]] && shift
+
+mkdir -p "$TIMING_DIR" "$LOGS_DIR"
+
+# Save existing timing if present (for no-op detection)
+OLD_START=""
+OLD_END=""
+if [[ -f "$TIMING_DIR/$PHASE.start" && -f "$TIMING_DIR/$PHASE.end" ]]; then
+    OLD_START=$(cat "$TIMING_DIR/$PHASE.start")
+    OLD_END=$(cat "$TIMING_DIR/$PHASE.end")
+fi
+
+# Record start time
+START_TIME=$(date +%s)
+echo "$START_TIME" > "$TIMING_DIR/$PHASE.start"
+echo ">>> Building $PHASE..."
+
+if [[ "$QUIET" == "1" ]]; then
+    # Quiet mode: redirect all output to log file
+    if "$@" > "$LOGS_DIR/$PHASE.log" 2>&1; then
+        echo "0" > "$TIMING_DIR/$PHASE.status"
+    else
+        echo "1" > "$TIMING_DIR/$PHASE.status"
+        date +%s > "$TIMING_DIR/$PHASE.end"
+        echo ""
+        echo "=== ERROR building $PHASE (last 100 lines) ==="
+        tail -100 "$LOGS_DIR/$PHASE.log"
+        exit 1
+    fi
+else
+    # Normal mode: show output directly
+    if "$@"; then
+        echo "0" > "$TIMING_DIR/$PHASE.status"
+    else
+        echo "1" > "$TIMING_DIR/$PHASE.status"
+        date +%s > "$TIMING_DIR/$PHASE.end"
+        exit 1
+    fi
+fi
+
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+
+# No-op detection: If build took < 30s AND we had previous timing, restore it
+# This preserves real build times when make re-runs stages as no-ops
+NOOP_THRESHOLD=30
+if [[ -n "$OLD_START" && -n "$OLD_END" && "$DURATION" -lt "$NOOP_THRESHOLD" ]]; then
+    OLD_DURATION=$((OLD_END - OLD_START))
+    # Only restore if old duration was significantly longer (real build)
+    if [[ "$OLD_DURATION" -gt "$NOOP_THRESHOLD" ]]; then
+        echo "$OLD_START" > "$TIMING_DIR/$PHASE.start"
+        echo "$OLD_END" > "$TIMING_DIR/$PHASE.end"
+        exit 0
+    fi
+fi
+
+echo "$END_TIME" > "$TIMING_DIR/$PHASE.end"

--- a/mk/timing-summary.sh
+++ b/mk/timing-summary.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# timing-summary.sh - Display and save timing information for build phases
+#
+# Usage: timing-summary.sh TIMING_DIR
+#
+# Auto-discovers phases from *.start files in TIMING_DIR. Displays top-level
+# phases (cabal, stage1, stage2, stage3-*, test) with their sub-phases indented.
+# Sub-phase durations are informational; TOTAL sums only top-level phases to
+# avoid double-counting.
+#
+# Also saves summary to TIMING_DIR/summary.txt
+
+set -uo pipefail
+
+TIMING_DIR="${1:-.}"
+
+# Format seconds into human-readable duration (right-aligned in 13 chars)
+format_duration() {
+    local dur=$1
+    local hrs=$((dur / 3600))
+    local mins=$(((dur % 3600) / 60))
+    local secs=$((dur % 60))
+
+    if [[ $hrs -gt 0 ]]; then
+        printf "%dh %2dm %2ds" "$hrs" "$mins" "$secs"
+    elif [[ $mins -gt 0 ]]; then
+        printf "%dm %2ds" "$mins" "$secs"
+    else
+        printf "%ds" "$secs"
+    fi
+}
+
+# Read status file and return OK/FAIL/-
+read_status() {
+    local phase=$1
+    local status
+    status=$(cat "$TIMING_DIR/$phase.status" 2>/dev/null || echo "?")
+    if [[ "$status" == "0" ]]; then
+        echo "OK"
+    elif [[ "$status" == "1" ]]; then
+        echo "FAIL"
+    else
+        echo "-"
+    fi
+}
+
+# Compute duration for a phase (returns -1 if files missing)
+phase_duration() {
+    local phase=$1
+    if [[ -f "$TIMING_DIR/$phase.start" ]] && [[ -f "$TIMING_DIR/$phase.end" ]]; then
+        local start end
+        start=$(cat "$TIMING_DIR/$phase.start")
+        end=$(cat "$TIMING_DIR/$phase.end")
+        echo $((end - start))
+    else
+        echo -1
+    fi
+}
+
+# Collect all completed phases (have both .start and .end files)
+declare -a all_phases=()
+if [[ -d "$TIMING_DIR" ]]; then
+    for f in "$TIMING_DIR"/*.start; do
+        [[ -f "$f" ]] || continue
+        phase=$(basename "$f" .start)
+        [[ -f "$TIMING_DIR/$phase.end" ]] || continue
+        all_phases+=("$phase")
+    done
+fi
+
+if [[ ${#all_phases[@]} -eq 0 ]]; then
+    echo "No timing data found in $TIMING_DIR"
+    exit 0
+fi
+
+# Classify phases: top-level vs sub-phase
+# Top-level: cabal, stage1, stage2, stage3-*, test
+# Sub-phase: anything with a dot (stage2.rts, stage3-x86_64-musl-linux.dist, etc.)
+declare -a top_level=()
+declare -a sub_phases=()
+
+for phase in "${all_phases[@]}"; do
+    if [[ "$phase" == *.* ]]; then
+        sub_phases+=("$phase")
+    else
+        top_level+=("$phase")
+    fi
+done
+
+# Define display order for top-level phases
+ordered_top_level() {
+    local -a ordered=()
+    # Fixed-order phases first
+    for p in cabal stage1 stage2; do
+        for t in "${top_level[@]}"; do
+            [[ "$t" == "$p" ]] && ordered+=("$t")
+        done
+    done
+    # stage3-* phases sorted alphabetically
+    for t in "${top_level[@]}"; do
+        [[ "$t" == stage3-* ]] && ordered+=("$t")
+    done
+    # test last
+    for t in "${top_level[@]}"; do
+        [[ "$t" == "test" ]] && ordered+=("$t")
+    done
+    # Anything else we missed
+    for t in "${top_level[@]}"; do
+        local found=0
+        for o in "${ordered[@]}"; do
+            [[ "$t" == "$o" ]] && found=1 && break
+        done
+        [[ $found -eq 0 ]] && ordered+=("$t")
+    done
+    printf '%s\n' "${ordered[@]}"
+}
+
+# Get sub-phases for a top-level phase, sorted alphabetically
+sub_phases_of() {
+    local parent=$1
+    for sp in "${sub_phases[@]}"; do
+        # Match: parent.suffix (single level only, no nested dots)
+        if [[ "$sp" == "$parent".* && "$sp" != "$parent".*.* ]]; then
+            echo "$sp"
+        fi
+    done | sort
+}
+
+# Column width for phase name (accommodates stage3-javascript-unknown-ghcjs.libraries)
+COL_PHASE=38
+
+# Print table
+sep="+$(printf '%0.s-' $(seq 1 $((COL_PHASE + 2))))+---------------+--------+"
+
+echo ""
+echo "$sep"
+printf "| %-${COL_PHASE}s | %-13s | %-6s |\n" "Phase" "Duration" "Status"
+echo "$sep"
+
+total=0
+while IFS= read -r phase; do
+    dur=$(phase_duration "$phase")
+    [[ $dur -lt 0 ]] && continue
+
+    total=$((total + dur))
+    dur_str=$(format_duration "$dur")
+    status_str=$(read_status "$phase")
+
+    printf "| %-${COL_PHASE}s | %13s | %-6s |\n" "$phase" "$dur_str" "$status_str"
+
+    # Print sub-phases indented
+    while IFS= read -r sp; do
+        [[ -z "$sp" ]] && continue
+        sp_dur=$(phase_duration "$sp")
+        [[ $sp_dur -lt 0 ]] && continue
+
+        sp_dur_str=$(format_duration "$sp_dur")
+        sp_status_str=$(read_status "$sp")
+
+        # Truncate long sub-phase names with ellipsis
+        display_name="  $sp"
+        if [[ ${#display_name} -gt $COL_PHASE ]]; then
+            display_name="${display_name:0:$((COL_PHASE - 1))}"$'\u2026'
+        fi
+
+        printf "| %-${COL_PHASE}s | %13s | %-6s |\n" "$display_name" "$sp_dur_str" "$sp_status_str"
+    done < <(sub_phases_of "$phase")
+
+done < <(ordered_top_level)
+
+echo "$sep"
+
+total_str=$(format_duration "$total")
+printf "| %-${COL_PHASE}s | %13s |        |\n" "TOTAL" "$total_str"
+echo "$sep"
+
+# Save summary to file (top-level phases only, for machine consumption)
+mkdir -p "$TIMING_DIR"
+rm -f "$TIMING_DIR/summary.txt"
+while IFS= read -r phase; do
+    dur=$(phase_duration "$phase")
+    [[ $dur -lt 0 ]] && continue
+    status=$(cat "$TIMING_DIR/$phase.status" 2>/dev/null || echo "?")
+    echo "$phase $dur $status" >> "$TIMING_DIR/summary.txt"
+
+    # Also record sub-phases
+    while IFS= read -r sp; do
+        [[ -z "$sp" ]] && continue
+        sp_dur=$(phase_duration "$sp")
+        [[ $sp_dur -lt 0 ]] && continue
+        sp_status=$(cat "$TIMING_DIR/$sp.status" 2>/dev/null || echo "?")
+        echo "$sp $sp_dur $sp_status" >> "$TIMING_DIR/summary.txt"
+    done < <(sub_phases_of "$phase")
+
+done < <(ordered_top_level)


### PR DESCRIPTION
## Summary

- Add timing information for build phases (cabal, stage1, stage2, bindist, test)
- Add `QUIET=1` mode to suppress output unless there's an error
- Show timing summary at end of build (even on failure)
- Save timing data to `_build/timing/summary.txt`
- Enable `QUIET=1` in devx CI workflow

## Usage

```bash
make                  # Normal build with timing summary at end
make QUIET=1          # Quiet build - output only on error
make timing-summary   # Show timing summary only
```

## Example Output

```
+------------------+---------------+--------+
| Phase            | Duration      | Status |
+------------------+---------------+--------+
| cabal            |        2m 15s | OK     |
| stage1           |       45m 10s | OK     |
| stage2           |     1h 24m 5s | OK     |
| bindist          |        1m 12s | OK     |
+------------------+---------------+--------+
| TOTAL            |    2h 12m 42s |        |
+------------------+---------------+--------+
```

## Test plan

- [ ] Run `make` and verify timing summary appears at end
- [ ] Run `make QUIET=1` and verify output is suppressed
- [ ] Verify logs are stored in `_build/logs/`
- [ ] Verify timing data is saved to `_build/timing/summary.txt`