### PR TITLE
feat: rebrand as Stable Haskell Edition

### DIFF
--- a/compiler/GHC/ByteCode/Linker.hs
+++ b/compiler/GHC/ByteCode/Linker.hs
@@ -223,7 +223,7 @@ linkFail who what
                 , "flags, or simply by naming the relevant files on the GHCi command line."
                 , "Alternatively, this link failure might indicate a bug in GHCi."
                 , "If you suspect the latter, please report this as a GHC bug:"
-                , "  https://www.haskell.org/ghc/reportabug"
+                , "  https://github.com/stable-haskell/ghc/issues"
                 ])
 
 

--- a/compiler/GHC/Core/Opt/ConstantFold.hs
+++ b/compiler/GHC/Core/Opt/ConstantFold.hs
@@ -3422,7 +3422,7 @@ caseRules _ (Var f `App` Type lev `App` Type ty `App` v) -- dataToTag x
       , "be a future bug in GHC, or it may be caused by an unsupported"
       , "use of the ghc-internal primops dataToTagSmall# and dataToTagLarge#."
       , "In either case, the GHC developers would like to know about it!"
-      , "Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug"
+      , "Please report this as a GHC bug:  https://github.com/stable-haskell/ghc/issues"
       ]
 
 caseRules _ _ = Nothing

--- a/compiler/GHC/Driver/Session.hs
+++ b/compiler/GHC/Driver/Session.hs
@@ -3468,6 +3468,7 @@ compilerInfo dflags
     : map (fmap $ expandDirectories (topDir dflags) (toolDir dflags))
           (rawSettings dflags)
    ++ [("Project version",             projectVersion dflags),
+       ("Edition",                     "Stable Haskell"),
        ("Project Git commit id",       cProjectGitCommitId),
        ("Project Version Int",         cProjectVersionInt),
        ("Project Patch Level",         cProjectPatchLevel),

--- a/compiler/GHC/Tc/Errors/Ppr.hs
+++ b/compiler/GHC/Tc/Errors/Ppr.hs
@@ -1657,7 +1657,7 @@ instance Diagnostic TcRnMessage where
     TcRnRoleValidationFailed role reason -> mkSimpleDecorated $
       vcat [text "Internal error in role inference:",
             pprRoleValidationFailedReason role reason,
-            text "Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug"]
+            text "Please report this as a GHC bug:  https://github.com/stable-haskell/ghc/issues"]
     TcRnCommonFieldResultTypeMismatch con1 con2 field_name -> mkSimpleDecorated $
       vcat [sep [text "Constructors" <+> ppr con1 <+> text "and" <+> ppr con2,
                  text "have a common field" <+> quotes (ppr field_name) <> comma],

--- a/compiler/GHC/Utils/Panic/Plain.hs
+++ b/compiler/GHC/Utils/Panic/Plain.hs
@@ -92,7 +92,7 @@ showPlainGhcException =
         showString "panic! (the 'impossible' happened)\n"
       . showString ("  GHC version " ++ cProjectVersion ++ ":\n\t")
       . s . showString "\n\n"
-      . showString "Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug\n"
+      . showString "Please report this as a GHC bug:  https://github.com/stable-haskell/ghc/issues\n"
 
 throwPlainGhcException :: PlainGhcException -> a
 throwPlainGhcException = Exception.throw

--- a/ghc/GHCi/UI.hs
+++ b/ghc/GHCi/UI.hs
@@ -199,8 +199,8 @@ defaultGhciSettings =
     }
 
 ghciWelcomeMsg :: String
-ghciWelcomeMsg = "GHCi, version " ++ cProjectVersion ++
-                 ": https://www.haskell.org/ghc/  :? for help"
+ghciWelcomeMsg = "GHCi, version " ++ cProjectVersion ++ " (Stable Haskell Edition)" ++
+                 ": https://github.com/stable-haskell/ghc  :? for help"
 
 ghciCommands :: [Command]
 ghciCommands = map mkCmd [

--- a/ghc/Main.hs
+++ b/ghc/Main.hs
@@ -385,7 +385,7 @@ showBanner _postLoadMode dflags = do
 
    -- Display details of the configuration in verbose mode
    when (verb >= 2) $
-    do hPutStr stderr "Glasgow Haskell Compiler, Version "
+    do hPutStr stderr "Glasgow Haskell Compiler (Stable Haskell Edition), Version "
        hPutStr stderr cProjectVersion
        hPutStr stderr ", stage "
        hPutStr stderr cStage
@@ -419,7 +419,7 @@ showSupportedExtensions m_top_dir = do
   mapM_ putStrLn $ supportedLanguagesAndExtensions arch_os
 
 showVersion :: IO ()
-showVersion = putStrLn (cProjectName ++ ", version " ++ cProjectVersion)
+showVersion = putStrLn (cProjectName ++ ", version " ++ cProjectVersion ++ " (Stable Haskell Edition)")
 
 showOptions :: Bool -> IO ()
 showOptions isInteractive = putStr (unlines availableOptions)

--- a/rts/RtsMessages.c
+++ b/rts/RtsMessages.c
@@ -179,7 +179,7 @@ rtsFatalInternalErrorFn(const char *s, va_list ap)
 #endif
      fprintf(stderr, "\n");
      fprintf(stderr, "    (GHC version %s for %s)\n", __GLASGOW_HASKELL_FULL_VERSION__, xstr(HostPlatform_TYPE));
-     fprintf(stderr, "    Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug\n");
+     fprintf(stderr, "    Please report this as a GHC bug:  https://github.com/stable-haskell/ghc/issues\n");
      fflush(stderr);
   }
 #if defined(mingw32_HOST_OS)

--- a/testsuite/tests/ghci/linking/T11531.stderr
+++ b/testsuite/tests/ghci/linking/T11531.stderr
@@ -7,5 +7,5 @@ the missing library using the -L/path/to/object/dir and -lmissinglibname
 flags, or simply by naming the relevant files on the GHCi command line.
 Alternatively, this link failure might indicate a bug in GHCi.
 If you suspect the latter, please report this as a GHC bug:
-  https://www.haskell.org/ghc/reportabug
+  https://github.com/stable-haskell/ghc/issues
 

--- a/testsuite/tests/rts/keep-cafs-fail.stdout
+++ b/testsuite/tests/rts/keep-cafs-fail.stdout
@@ -1,5 +1,5 @@
 KeepCafsMain: internal error: Evaluated a CAF (0xaac9d8) that was GC'd!
     (GHC version 8.7.20180910 for x86_64_unknown_linux)
-    Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug
+    Please report this as a GHC bug:  https://github.com/stable-haskell/ghc/issues
 Aborted (core dumped)
 exit(134)

--- a/testsuite/tests/rts/linker/T11223/T11223_link_order_a_b_2_fail.stderr
+++ b/testsuite/tests/rts/linker/T11223/T11223_link_order_a_b_2_fail.stderr
@@ -21,5 +21,5 @@ the missing library using the -L/path/to/object/dir and -lmissinglibname
 flags, or simply by naming the relevant files on the GHCi command line.
 Alternatively, this link failure might indicate a bug in GHCi.
 If you suspect the latter, please report this as a GHC bug:
-  https://www.haskell.org/ghc/reportabug
+  https://github.com/stable-haskell/ghc/issues
 

--- a/testsuite/tests/rts/linker/T11223/T11223_link_order_a_b_2_fail.stderr-ws-64-mingw32
+++ b/testsuite/tests/rts/linker/T11223/T11223_link_order_a_b_2_fail.stderr-ws-64-mingw32
@@ -21,5 +21,5 @@ the missing library using the -L/path/to/object/dir and -lmissinglibname
 flags, or simply by naming the relevant files on the GHCi command line.
 Alternatively, this link failure might indicate a bug in GHCi.
 If you suspect the latter, please report this as a GHC bug:
-  https://www.haskell.org/ghc/reportabug
+  https://github.com/stable-haskell/ghc/issues
 

--- a/testsuite/tests/rts/linker/T11223/T11223_simple_duplicate_lib.stderr
+++ b/testsuite/tests/rts/linker/T11223/T11223_simple_duplicate_lib.stderr
@@ -21,5 +21,5 @@ the missing library using the -L/path/to/object/dir and -lmissinglibname
 flags, or simply by naming the relevant files on the GHCi command line.
 Alternatively, this link failure might indicate a bug in GHCi.
 If you suspect the latter, please report this as a GHC bug:
-  https://www.haskell.org/ghc/reportabug
+  https://github.com/stable-haskell/ghc/issues
 

--- a/testsuite/tests/rts/linker/T11223/T11223_simple_duplicate_lib.stderr-ws-64-mingw32
+++ b/testsuite/tests/rts/linker/T11223/T11223_simple_duplicate_lib.stderr-ws-64-mingw32
@@ -21,5 +21,5 @@ the missing library using the -L/path/to/object/dir and -lmissinglibname
 flags, or simply by naming the relevant files on the GHCi command line.
 Alternatively, this link failure might indicate a bug in GHCi.
 If you suspect the latter, please report this as a GHC bug:
-  https://www.haskell.org/ghc/reportabug
+  https://github.com/stable-haskell/ghc/issues
 


### PR DESCRIPTION
## Summary

Add "Stable Haskell Edition" branding to user-visible output while maintaining drop-in compatibility with upstream GHC:

- `ghc --version`: Append "(Stable Haskell Edition)" suffix
- `ghc -v2` banner: Add edition to verbose compiler banner
- GHCi welcome: Add edition and update URL to GitHub repo
- `ghc --info`: Add new "Edition" field (keeps "Project name" unchanged for tool compat)
- Bug reports: Redirect all URLs to `github.com/stable-haskell/ghc/issues`

## Compatibility

- **ABI compatible**: `cProjectVersion`, `cProjectUnitId`, and internal identifiers unchanged
- **Tool compatible**: `ghc --info` "Project name" unchanged; new "Edition" field added
- **Drop-in replacement**: Users can substitute this GHC for upstream GHC

## Files Changed

| File | Change |
|------|--------|
| `ghc/Main.hs` | Version output and verbose banner |
| `ghc/GHCi/UI.hs` | GHCi welcome message |
| `compiler/GHC/Driver/Session.hs` | Add "Edition" field to `ghc --info` |
| `compiler/GHC/Utils/Panic/Plain.hs` | Bug report URL |
| `compiler/GHC/Tc/Errors/Ppr.hs` | Bug report URL |
| `compiler/GHC/ByteCode/Linker.hs` | Bug report URL |
| `compiler/GHC/Core/Opt/ConstantFold.hs` | Bug report URL (also fixed HTTP→HTTPS) |
| `rts/RtsMessages.c` | Bug report URL |

## Test plan

- [ ] Build stage2 compiler
- [ ] Verify `ghc --version` shows "(Stable Haskell Edition)"
- [ ] Verify `ghc --info` includes `("Edition", "Stable Haskell")`
- [ ] Verify GHCi welcome banner shows edition and GitHub URL