### PR TITLE
compiler: fix comment to match renamed linkExecutable

### DIFF
--- a/compiler/GHC/Driver/Pipeline.hs
+++ b/compiler/GHC/Driver/Pipeline.hs
@@ -452,7 +452,7 @@ link' logger tmpfs fc dflags unit_env batch_attempt_linking mHscMessager hpt
 
         debugTraceMsg logger 3 (text "link: done")
 
-        -- linkBinary only returns if it succeeds
+        -- linkExecutable only returns if it succeeds
         return Succeeded
 
    | otherwise


### PR DESCRIPTION
## Summary
- Updates a stale comment that still referenced `linkBinary` after the rename to `linkExecutable` in 55ff022013.

## Test plan
- No functional change, comment-only fix.