### PR TITLE
rts: Fix AutoApply header installation paths

### DIFF
--- a/rts/rts.cabal
+++ b/rts/rts.cabal
@@ -693,10 +693,10 @@ library
       DerivedConstants.h
       rts/EventLogConstants.h
       rts/EventTypes.h
-      AutoApply.cmm.h
-      AutoApply_V16.cmm.h
-      AutoApply_V32.cmm.h
-      AutoApply_V64.cmm.h
+      rts/AutoApply.cmm.h
+      rts/AutoApply_V16.cmm.h
+      rts/AutoApply_V32.cmm.h
+      rts/AutoApply_V64.cmm.h
 
     install-includes:
       ghcautoconf.h
@@ -704,10 +704,10 @@ library
       DerivedConstants.h
       rts/EventLogConstants.h
       rts/EventTypes.h
-      AutoApply.cmm.h
-      AutoApply_V16.cmm.h
-      AutoApply_V32.cmm.h
-      AutoApply_V64.cmm.h
+      rts/AutoApply.cmm.h
+      rts/AutoApply_V16.cmm.h
+      rts/AutoApply_V32.cmm.h
+      rts/AutoApply_V64.cmm.h
 
     install-includes:
       -- Common headers for non-JS builds


### PR DESCRIPTION
Fixes path mismatch in rts.cabal for AutoApply generated headers.

The headers are generated into include/rts/ subdirectory (by configure.ac), but rts.cabal specified them without the rts/ prefix. This prevented proper file discovery and installation.

Updates both autogen-includes and install-includes sections to use rts/AutoApply*.cmm.h paths.