### PR TITLE
ghc-internal: Add --with-compiler configure option

### DIFF
--- a/libraries/ghc-internal/configure.ac
+++ b/libraries/ghc-internal/configure.ac
@@ -411,7 +411,15 @@ AS_IF([test "$ac_cv_sizeof_struct_MD5Context" -eq 0],[
 ])
 
 AC_ARG_VAR([GHC], [Path to the ghc program])
-AC_PATH_PROG([GHC], ghc)
+
+AC_ARG_WITH([compiler],
+  [AS_HELP_STRING([--with-compiler],
+    [The haskell compiler to use])],
+      [GHC="$withval"
+       AC_MSG_NOTICE([Using GHC $GHC])
+      ],
+      [AC_PATH_PROG([GHC], ghc)])
+
 if test -z "$GHC"; then
 	AC_MSG_ERROR([Cannot find ghc])
 fi


### PR DESCRIPTION
Add `AC_ARG_WITH([compiler])` to allow specifying the Haskell compiler via the `--with-compiler` flag.

This makes ghc-internal's configure script consistent with standard autoconf practices for tool configuration. Users can now specify the compiler in multiple ways:
- `--with-compiler=/path/to/ghc` (configure flag)
- `GHC=/path/to/ghc` (environment variable)
- Auto-detection via PATH

This improves flexibility when building with non-standard compiler locations.