### PR TITLE
Deprecate -dynamic-too: replace duplicate compilation with symlinks

### DIFF
--- a/compiler/GHC/Driver/Main.hs
+++ b/compiler/GHC/Driver/Main.hs
@@ -1428,20 +1428,17 @@ hscMaybeWriteIface logger dflags is_simple iface old_iface mod_location = do
 
     if (write_interface || force_write_interface) then do
 
-      -- FIXME: with -dynamic-too, "change" is only meaningful for the
-      -- non-dynamic interface, not for the dynamic one. We should have another
-      -- flag for the dynamic interface. In the meantime:
-      --
-      --    * when we write a single full interface, we check if we are
-      --    currently writing the dynamic interface due to -dynamic-too, in
-      --    which case we ignore "change".
-      --
-      --    * when we write two simple interfaces at once because of
-      --    dynamic-too, we use "change" both for the non-dynamic and the
-      --    dynamic interfaces. Hopefully both the dynamic and the non-dynamic
-      --    interfaces stay in sync...
-      --
       let change = old_iface /= Just (mi_iface_hash iface)
+
+      -- Create a relative symlink from .dyn_hi -> .hi.
+      -- Used when -dynamic-too is active (deprecated).
+      let symlink_dyn_hi = do
+            let hi_file     = ml_hi_file mod_location
+                dyn_hi_file = ml_dyn_hi_file mod_location
+                rel_hi      = FilePath.takeFileName hi_file
+            exists <- doesPathExist dyn_hi_file
+            when exists $ removeFile dyn_hi_file
+            createFileLink rel_hi dyn_hi_file
 
       let dt = dynamicTooState dflags
 
@@ -1453,16 +1450,20 @@ hscMaybeWriteIface logger dflags is_simple iface old_iface mod_location = do
          ]
 
       if is_simple
-         then when change $ do -- FIXME: see 'change' comment above
+         then when change $ do
             write_iface dflags iface
             case dt of
                DT_Dont   -> return ()
                DT_Dyn    -> panic "Unexpected DT_Dyn state when writing simple interface"
-               DT_OK     -> write_iface (setDynamicNow dflags) iface
+               -- -dynamic-too is deprecated: create a symlink .dyn_hi -> .hi
+               -- instead of writing a second copy of the interface file.
+               DT_OK     -> symlink_dyn_hi
          else case dt of
                DT_Dont | change                    -> write_iface dflags iface
-               DT_OK   | change                    -> write_iface dflags iface
-               -- FIXME: see change' comment above
+               DT_OK   | change                    -> do
+                  write_iface dflags iface
+                  -- -dynamic-too is deprecated: create .dyn_hi -> .hi symlink
+                  symlink_dyn_hi
                DT_Dyn                              -> write_iface dflags iface
                _                                   -> return ()
 

--- a/compiler/GHC/Driver/Pipeline.hs
+++ b/compiler/GHC/Driver/Pipeline.hs
@@ -788,22 +788,32 @@ hscBackendPipeline pipe_env hsc_env mod_sum result =
   if backendGeneratesCode (backend (hsc_dflags hsc_env)) then
     do
       res <- hscGenBackendPipeline pipe_env hsc_env mod_sum result
-      -- Only run dynamic-too if the backend generates object files
-      -- See Note [Writing interface files]
-      -- If we are writing a simple interface (not . backendWritesFiles), then
-      -- hscMaybeWriteIface in the regular pipeline will write both the hi and
-      -- dyn_hi files. This way we can avoid running the pipeline twice and
-      -- generating a duplicate linkable.
-      -- We must not run the backend a second time with `dynamicNow` enable because
-      -- all the work has already been done in the first pipeline.
-      when (gopt Opt_BuildDynamicToo (hsc_dflags hsc_env) && backendWritesFiles (backend (hsc_dflags hsc_env)) ) $ do
-          let dflags' = setDynamicNow (hsc_dflags hsc_env) -- set "dynamicNow"
-          () <$ hscGenBackendPipeline pipe_env (hscSetFlags dflags' hsc_env) mod_sum result
+      -- -dynamic-too is deprecated: instead of running the backend a second
+      -- time to produce .dyn_o files, we create a symlink .dyn_o -> .o
+      -- since all object files are now dynamic-capable.
+      when (gopt Opt_BuildDynamicToo (hsc_dflags hsc_env) && backendWritesFiles (backend (hsc_dflags hsc_env)) ) $ liftIO $ do
+          let location = ms_location mod_sum
+              obj_fn     = ml_obj_file location
+              dyn_obj_fn = ml_dyn_obj_file location
+          createOrUpdateSymlink obj_fn dyn_obj_fn
       return res
   else
     case result of
       HscUpdate iface ->  return (iface, emptyRecompLinkables)
       HscRecomp {} -> (,) <$> liftIO (mkFullIface hsc_env (hscs_partial_iface result) Nothing Nothing NoStubs []) <*> pure emptyRecompLinkables
+
+-- | Create a symlink from @link@ pointing to @source@, removing any
+-- existing file or symlink at @link@ first. Used by the deprecated
+-- -dynamic-too path to create .dyn_o -> .o and .dyn_hi -> .hi symlinks.
+createOrUpdateSymlink :: FilePath -> FilePath -> IO ()
+createOrUpdateSymlink source link = do
+  -- Use the basename of source so the symlink is relative
+  -- (both files live in the same directory).
+  let relSource = takeFileName source
+  -- doesPathExist detects files, directories, and symlinks (including broken ones)
+  exists <- doesPathExist link
+  when exists $ removeFile link
+  createFileLink relSource link
 
 hscGenBackendPipeline :: P m
   => PipeEnv

--- a/compiler/GHC/Driver/Session.hs
+++ b/compiler/GHC/Driver/Session.hs
@@ -1276,8 +1276,9 @@ dynamic_flags_deps = [
   , make_ord_flag defGhcFlag "ddump-file-prefix"
         (hasArg (setDumpPrefixForce . Just . flip (++) "."))
 
-  , make_ord_flag defGhcFlag "dynamic-too"
+  , make_dep_flag defGhcFlag "dynamic-too"
         (NoArg (setGeneralFlag Opt_BuildDynamicToo))
+        "-dynamic-too is deprecated. All object files are now dynamic-capable; .dyn_o/.dyn_hi are created as symlinks."
 
         ------- Keeping temporary files -------------------------------------
      -- These can be singular (think ghc -c) or plural (think ghc --make)


### PR DESCRIPTION
## Summary

- Deprecates `-dynamic-too` with a compiler warning
- Replaces the second backend pass (which re-ran codegen to produce `.dyn_o`/`.dyn_hi`) with symlink creation: `.dyn_o -> .o` and `.dyn_hi -> .hi`
- Since all `.o` files are now dynamic-capable, the duplicate compilation is unnecessary

## Changes

- **`compiler/GHC/Driver/Session.hs`**: Mark `-dynamic-too` as deprecated via `make_dep_flag`
- **`compiler/GHC/Driver/Pipeline.hs`**: Replace second `hscGenBackendPipeline` call with `.dyn_o -> .o` symlink creation
- **`compiler/GHC/Driver/Main.hs`**: Replace second `write_iface` call with `.dyn_hi -> .hi` symlink creation

## Test plan

- [ ] CI passes on all platforms (x86_64-linux, aarch64-linux, aarch64-darwin, x86_64-darwin, FreeBSD)
- [ ] Existing `-dynamic-too` tests still pass (symlinks satisfy file existence checks)
- [ ] Deprecation warning is emitted when `-dynamic-too` is used