### PR TITLE
hsc2hs: batch cross-compilation for massive speedup

### DIFF
--- a/cabal.project.stage1
+++ b/cabal.project.stage1
@@ -42,7 +42,7 @@ packages:
   https://hackage.haskell.org/package/semaphore-compat-1.0.0/semaphore-compat-1.0.0.tar.gz
   https://hackage.haskell.org/package/unix-2.8.8.0/unix-2.8.8.0.tar.gz
   https://hackage.haskell.org/package/Win32-2.14.2.1/Win32-2.14.2.1.tar.gz
-  https://hackage.haskell.org/package/hsc2hs-0.68.10/hsc2hs-0.68.10.tar.gz
+  -- hsc2hs: see source-repository-package below
 
 allow-newer: directory:*
            , file-io:*
@@ -83,3 +83,10 @@ package ghc-boot
 
 package ghc-boot-th-next
   flags: +bootstrap
+
+-- hsc2hs with batch cross-compilation support
+-- https://github.com/stable-haskell/hsc2hs/tree/feat/batch-cross-compilation
+source-repository-package
+  type: git
+  location: https://github.com/stable-haskell/hsc2hs.git
+  tag: bf966e825d34c7776a988f473f1c437b89e8a21f

--- a/cabal.project.stage1
+++ b/cabal.project.stage1
@@ -89,4 +89,4 @@ package ghc-boot-th-next
 source-repository-package
   type: git
   location: https://github.com/stable-haskell/hsc2hs.git
-  tag: bf966e825d34c7776a988f473f1c437b89e8a21f
+  tag: d07eea1260894ce5fe456f881fbc62366c9eb1b7

--- a/cabal.project.stage2
+++ b/cabal.project.stage2
@@ -50,7 +50,7 @@ packages:
   libraries/Cabal/Cabal-syntax
 
   utils/hpc
-  https://hackage.haskell.org/package/hsc2hs-0.68.10/hsc2hs-0.68.10.tar.gz
+  -- hsc2hs: see source-repository-package below
 
   https://hackage.haskell.org/package/Win32-2.14.2.1/Win32-2.14.2.1.tar.gz
   https://hackage.haskell.org/package/array-0.5.8.0/array-0.5.8.0.tar.gz
@@ -196,3 +196,10 @@ package rts-headers
 
 package rts-fs
   ghc-options: -no-rts
+
+-- hsc2hs with batch cross-compilation support
+-- https://github.com/stable-haskell/hsc2hs/tree/feat/batch-cross-compilation
+source-repository-package
+  type: git
+  location: https://github.com/stable-haskell/hsc2hs.git
+  tag: bf966e825d34c7776a988f473f1c437b89e8a21f

--- a/cabal.project.stage2
+++ b/cabal.project.stage2
@@ -202,4 +202,4 @@ package rts-fs
 source-repository-package
   type: git
   location: https://github.com/stable-haskell/hsc2hs.git
-  tag: bf966e825d34c7776a988f473f1c437b89e8a21f
+  tag: d07eea1260894ce5fe456f881fbc62366c9eb1b7


### PR DESCRIPTION
## Summary

- Batch all constant-like hsc2hs directives (`#const`, `#size`, `#alignment`, `#peek`, `#poke`, `#ptr`, `#offset`, `#enum`) into a single C→assembly compilation instead of one compilation per directive
- Reduces compiler invocations from O(n) to O(1) per `.hsc` file during cross-compilation
- For `Flags.hsc` (146 directives): **147 → 2 compilations** (73x fewer)
- Falls through to existing per-directive path on batch miss (fully transparent, identical output)
- Added `--no-batch` flag for debugging/fallback
- Graceful degradation for non-AT&T compilers (e.g. emcc for WebAssembly)

## How it works

1. **Collection pass** — walks the token stream, tracking conditional nesting (`#if`/`#ifdef`/`#else`/`#elif`), and collects all batchable directives with their C expressions and conditional context
2. **Single compilation** — generates one C file with all entries (each wrapped in its conditional guards), compiles to assembly (`-S`), parses with the existing ATT assembly parser to extract all values
3. **Fast lookup** — results are stored in a `Map (line, col) Integer` for O(log n) lookup during output generation
4. **Fallback** — if a constant isn't in the batch results (e.g., batch compilation failed, ATT parser can't handle the output format, or directive was inside a false conditional branch), falls through to the existing `computeConst` path with zero behavioral change

## Performance

| Scenario | Before (via-asm) | Before (non-via-asm) | **After (batched)** |
|----------|-----------------|---------------------|-------------------|
| Per file | N+1 compilations | ~28N+1 compilations | **2 compilations** |
| Flags.hsc (146 dirs) | 147 | ~4,089 | **2** |

## Changes

- `cabal.project.stage1` / `cabal.project.stage2` — replace hackage hsc2hs-0.68.10 with stable-haskell/hsc2hs fork archive URL

### Fork changes ([stable-haskell/hsc2hs@feat/batch-cross-compilation](https://github.com/stable-haskell/hsc2hs/tree/feat/batch-cross-compilation))

- `src/CrossCodegen.hs` — batch collection, C generation, compilation, resolution, integration with `diagnose`/`outputSpecial` (+243 lines)
- `src/Flags.hs` — `cNoBatch` field and `--no-batch` CLI option
- `src/Main.hs` — wire up `cNoBatch`

## Test plan

- [x] `cabal build hsc2hs` compiles cleanly
- [x] All 93 existing tests pass (`cabal test`)
- [x] Batch output identical to `--no-batch` output (verified with `diff` on multiple test files)
- [x] All directive types verified: `#const`, `#size`, `#alignment`, `#peek`, `#poke`, `#ptr`, `#offset`
- [x] Conditional handling verified: `#ifdef`/`#else` branches correctly include/exclude constants
- [x] Works both with and without `--via-asm` flag
- [x] ATTParser errors gracefully caught for non-AT&T compilers (emcc/WebAssembly)
- [ ] Full GHC cross-compilation build