### PR TITLE
AArch64 NCG: Peephole optimizer, new instructions, and codegen improvements

### DIFF
--- a/compiler/GHC/CmmToAsm/AArch64/CodeGen.hs
+++ b/compiler/GHC/CmmToAsm/AArch64/CodeGen.hs
@@ -17,7 +17,7 @@ import Data.Word
 import GHC.Platform.Regs
 import GHC.CmmToAsm.AArch64.Instr
 import GHC.CmmToAsm.AArch64.Regs
-import GHC.CmmToAsm.AArch64.Cond
+import GHC.CmmToAsm.AArch64.Cond (Cond(..), invertCond)
 
 import GHC.CmmToAsm.CPrim
 import GHC.Cmm.DebugBlock
@@ -418,13 +418,12 @@ which will then be transalted to one of the immediate encodings implicitly.
 For example mov x1, #0x10000 is allowed but will be assembled to movz x1, #0x1, lsl #16
 -}
 
--- | Move (wide immediate)
+-- | Move (wide immediate) for MOVZ.
 -- Allows for 16bit immediate which can be shifted by 0/16/32/48 bits.
--- Used with MOVZ,MOVN, MOVK
+-- Used with MOVZ. Only handles non-negative values.
 -- See Note [Aarch64 immediates]
 getMovWideImm :: Integer -> Width -> Maybe Operand
 getMovWideImm n w
-  -- TODO: Handle sign extension/negatives
   | n <= 0
   = Nothing
   -- Fits in 16 bits
@@ -449,6 +448,57 @@ getMovWideImm n w
     truncated = narrowU w n
     sized_n = fromIntegral truncated :: Word64
     trailing_zeros = countTrailingZeros sized_n
+
+-- | Move (wide immediate) for MOVN.
+-- MOVN writes NOT(imm16 << shift) to the register. This is optimal for
+-- values where the bitwise complement has a single non-zero 16-bit halfword.
+-- Returns the operand for the MOVN instruction.
+-- See Note [Aarch64 immediates]
+getMovNImm :: Integer -> Width -> Maybe Operand
+getMovNImm n w
+  | inverted_n < 2^(16 :: Int)
+  = Just $ OpImm (ImmInteger (fromIntegral inverted_n))
+  | inv_trailing_zeros >= 16 && inverted_n < 2^(32 :: Int)
+  = Just $ OpImmShift (ImmInteger (fromIntegral (inverted_n `shiftR` 16))) SLSL 16
+  | inv_trailing_zeros >= 32 && inverted_n < 2^(48 :: Int)
+  = Just $ OpImmShift (ImmInteger (fromIntegral (inverted_n `shiftR` 32))) SLSL 32
+  | inv_trailing_zeros >= 48
+  = Just $ OpImmShift (ImmInteger (fromIntegral (inverted_n `shiftR` 48))) SLSL 48
+  | otherwise
+  = Nothing
+  where
+    -- Complement within the register width
+    truncated = narrowU w n
+    mask = case w of
+      W32 -> 0xFFFFFFFF
+      W64 -> 0xFFFFFFFFFFFFFFFF
+      _   -> (1 `shiftL` widthInBits w) - 1
+    inverted_n = (complement truncated) .&. mask :: Integer
+    inv_trailing_zeros = countTrailingZeros (fromIntegral inverted_n :: Word64)
+
+-- | Check if an integer is a power of 2. Returns the bit position if so.
+-- Used for TBZ/TBNZ pattern matching.
+-- We convert to Word64 for countTrailingZeros since Integer lacks FiniteBits.
+isPowerOf2 :: Integer -> Maybe Int
+isPowerOf2 n
+  | n > 0, n .&. (n - 1) == 0 = Just (countTrailingZeros (fromIntegral n :: Word64))
+  | otherwise = Nothing
+
+-- | Count non-0x0000 halfwords in a value (for MOVZ cost estimation)
+movzCost :: Word64 -> Int
+movzCost w = length $ filter (/= 0) halfwords
+  where halfwords = [ w .&. 0xFFFF
+                    , (w `shiftR` 16) .&. 0xFFFF
+                    , (w `shiftR` 32) .&. 0xFFFF
+                    , (w `shiftR` 48) .&. 0xFFFF ]
+
+-- | Count non-0xFFFF halfwords in a value (for MOVN cost estimation)
+movnCost :: Word64 -> Int
+movnCost w = length $ filter (/= 0xFFFF) halfwords
+  where halfwords = [ w .&. 0xFFFF
+                    , (w `shiftR` 16) .&. 0xFFFF
+                    , (w `shiftR` 32) .&. 0xFFFF
+                    , (w `shiftR` 48) .&. 0xFFFF ]
 
 -- | Arithmetic(immediate)
 --  Allows for 12bit immediates which can be shifted by 0 or 12 bits.
@@ -653,6 +703,12 @@ getRegister' config plat expr
                    , Just imm_op <- getMovWideImm i w -> do
           return (Any (intFormat w) (\dst -> unitOL $ annExpr expr (MOVZ (OpReg w dst) imm_op)))
 
+        -- MOVN for negative values: MOVN writes NOT(imm16 << shift).
+        -- This handles common negative values like -1, -4, -8, etc. in a
+        -- single instruction instead of a 2-4 instruction MOVZ+MOVK chain.
+        CmmInt i w | Just imm_op <- getMovNImm i w -> do
+          return (Any (intFormat w) (\dst -> unitOL $ annExpr expr (MOVN (OpReg w dst) imm_op)))
+
         CmmInt i w | isNbitEncodeable 16 i, i >= 0 -> do
           return (Any (intFormat w) (\dst -> unitOL $ annExpr expr (MOV (OpReg W16 dst) (OpImm (ImmInteger i)))))
 
@@ -663,26 +719,75 @@ getRegister' config plat expr
                                                   $ MOV (OpReg W32 dst) (OpImm (ImmInt half0))
                                                   , MOVK (OpReg W32 dst) (OpImmShift (ImmInt half1) SLSL 16)
                                                   ]))
-        -- fallback for W32
+
+        -- Smart constant materialization: choose between MOVZ+MOVK and
+        -- MOVN+MOVK based on which needs fewer instructions.
+        -- MOVZ is better when most halfwords are 0x0000.
+        -- MOVN is better when most halfwords are 0xFFFF (common for negatives).
         CmmInt i W32 -> do
-          let  half0 = fromIntegral (fromIntegral i :: Word16)
-               half1 = fromIntegral (fromIntegral (i `shiftR` 16) :: Word16)
-          return (Any (intFormat W32) (\dst -> toOL [ annExpr expr
-                                                    $ MOV (OpReg W32 dst) (OpImm (ImmInt half0))
-                                                    , MOVK (OpReg W32 dst) (OpImmShift (ImmInt half1) SLSL 16)
-                                                    ]))
-        -- anything else
+          let unsigned = narrowU W32 i
+              word = fromIntegral unsigned :: Word64
+              half0 = fromIntegral (word .&. 0xFFFF) :: Int
+              half1 = fromIntegral ((word `shiftR` 16) .&. 0xFFFF) :: Int
+          return $ if movnCost word < movzCost word
+            then Any (intFormat W32) $ \dst ->
+              -- Use MOVN + MOVK: fewer instructions for values with many 0xFFFF halfwords
+              let inv = (complement word) .&. 0xFFFFFFFF
+                  halves = [(half0, 0 :: Int), (half1, 16)]
+                  -- Pick the first non-0xFFFF halfword for the MOVN base
+                  (base_inv, base_shift) = case [ (fromIntegral ((inv `shiftR` s) .&. 0xFFFF) :: Int, s)
+                                                 | (h, s) <- halves, h /= 0xFFFF ] of
+                    (x:_) -> x
+                    []    -> (fromIntegral (inv .&. 0xFFFF), 0)  -- all 0xFFFF: handled by getMovNImm above
+                  movn_op = if base_shift == 0 then OpImm (ImmInt base_inv)
+                            else OpImmShift (ImmInt base_inv) SLSL base_shift
+                  movk_fixups = [ MOVK (OpReg W32 dst) (OpImmShift (ImmInt h) SLSL s)
+                                | (h, s) <- halves
+                                , s /= base_shift
+                                , h /= 0xFFFF ]
+              in annExpr expr (MOVN (OpReg W32 dst) movn_op) `consOL` toOL movk_fixups
+            else Any (intFormat W32) $ \dst ->
+              toOL [ annExpr expr $ MOV (OpReg W32 dst) (OpImm (ImmInt half0))
+                   , MOVK (OpReg W32 dst) (OpImmShift (ImmInt half1) SLSL 16) ]
+
+        -- W64: smart constant materialization
         CmmInt i W64 -> do
-          let  half0 = fromIntegral (fromIntegral i :: Word16)
-               half1 = fromIntegral (fromIntegral (i `shiftR` 16) :: Word16)
-               half2 = fromIntegral (fromIntegral (i `shiftR` 32) :: Word16)
-               half3 = fromIntegral (fromIntegral (i `shiftR` 48) :: Word16)
-          return (Any (intFormat W64) (\dst -> toOL [ annExpr expr
-                                                    $ MOV (OpReg W64 dst) (OpImm (ImmInt half0))
-                                                    , MOVK (OpReg W64 dst) (OpImmShift (ImmInt half1) SLSL 16)
-                                                    , MOVK (OpReg W64 dst) (OpImmShift (ImmInt half2) SLSL 32)
-                                                    , MOVK (OpReg W64 dst) (OpImmShift (ImmInt half3) SLSL 48)
-                                                    ]))
+          let unsigned = narrowU W64 i
+              word = fromIntegral unsigned :: Word64
+              half0 = fromIntegral (word .&. 0xFFFF) :: Int
+              half1 = fromIntegral ((word `shiftR` 16) .&. 0xFFFF) :: Int
+              half2 = fromIntegral ((word `shiftR` 32) .&. 0xFFFF) :: Int
+              half3 = fromIntegral ((word `shiftR` 48) .&. 0xFFFF) :: Int
+          return $ if movnCost word < movzCost word
+            then Any (intFormat W64) $ \dst ->
+              -- Use MOVN + MOVK chain
+              let inv = complement word
+                  halves = [(half0, 0 :: Int), (half1, 16), (half2, 32), (half3, 48)]
+                  (base_inv, base_shift) = case [ (fromIntegral ((inv `shiftR` s) .&. 0xFFFF) :: Int, s)
+                                                 | (h, s) <- halves, h /= 0xFFFF ] of
+                    (x:_) -> x
+                    []    -> (fromIntegral (inv .&. 0xFFFF), 0)
+                  movn_op = if base_shift == 0 then OpImm (ImmInt base_inv)
+                            else OpImmShift (ImmInt base_inv) SLSL base_shift
+                  movk_fixups = [ MOVK (OpReg W64 dst) (OpImmShift (ImmInt h) SLSL s)
+                                | (h, s) <- halves
+                                , s /= base_shift
+                                , h /= 0xFFFF ]
+              in annExpr expr (MOVN (OpReg W64 dst) movn_op) `consOL` toOL movk_fixups
+            else Any (intFormat W64) $ \dst ->
+              -- MOVZ+MOVK path: skip zero halfwords since MOVZ zeroes them.
+              -- Pick the first non-zero halfword for MOVZ, then MOVK the rest.
+              let all_halves = [(half0, 0 :: Int), (half1, 16), (half2, 32), (half3, 48)]
+                  (base_h, base_s) = case [(h,s) | (h,s) <- all_halves, h /= 0] of
+                    (x:_) -> x
+                    []    -> (0, 0)  -- all zero: single MOVZ #0
+                  movz_op = if base_s == 0 then OpImm (ImmInt base_h)
+                            else OpImmShift (ImmInt base_h) SLSL base_s
+                  movk_fixups = [ MOVK (OpReg W64 dst) (OpImmShift (ImmInt h) SLSL s)
+                                | (h, s) <- all_halves
+                                , s /= base_s
+                                , h /= 0 ]
+              in annExpr expr (MOVZ (OpReg W64 dst) movz_op) `consOL` toOL movk_fixups
         CmmInt _i rep -> do
           (op, imm_code) <- litToImm' lit
           return (Any (intFormat rep) (\dst -> imm_code `snocOL` annExpr expr (MOV (OpReg rep dst) op)))
@@ -1544,6 +1649,31 @@ genCondJump bid expr = do
         (reg_x, _format_x, code_x) <- getSomeReg x
         return $ code_x `snocOL`  (annExpr expr (CBNZ (OpReg w reg_x) (TBlock bid)))
 
+      -- TBZ/TBNZ: test single bit and branch.
+      -- Matches: (x & (1 << bit)) == 0  →  TBZ x, #bit, label
+      -- Matches: (x & (1 << bit)) /= 0  →  TBNZ x, #bit, label
+      CmmMachOp (MO_Eq _) [CmmMachOp (MO_And w) [x, CmmLit (CmmInt mask _)], CmmLit (CmmInt 0 _)]
+        | Just bit <- isPowerOf2 mask
+        , bit < widthInBits w -> do
+          (reg_x, _format_x, code_x) <- getSomeReg x
+          return $ code_x `snocOL` annExpr expr (TBZ (OpReg w reg_x) bit (TBlock bid))
+
+      CmmMachOp (MO_Ne _) [CmmMachOp (MO_And w) [x, CmmLit (CmmInt mask _)], CmmLit (CmmInt 0 _)]
+        | Just bit <- isPowerOf2 mask
+        , bit < widthInBits w -> do
+          (reg_x, _format_x, code_x) <- getSomeReg x
+          return $ code_x `snocOL` annExpr expr (TBNZ (OpReg w reg_x) bit (TBlock bid))
+
+      -- Sign bit test: x < 0  →  TBNZ x, #(width-1), label (sign bit set)
+      CmmMachOp (MO_S_Lt w) [x, CmmLit (CmmInt 0 _)] -> do
+        (reg_x, _format_x, code_x) <- getSomeReg x
+        return $ code_x `snocOL` annExpr expr (TBNZ (OpReg w reg_x) (widthInBits w - 1) (TBlock bid))
+
+      -- Sign bit test: x >= 0  →  TBZ x, #(width-1), label (sign bit clear)
+      CmmMachOp (MO_S_Ge w) [x, CmmLit (CmmInt 0 _)] -> do
+        (reg_x, _format_x, code_x) <- getSomeReg x
+        return $ code_x `snocOL` annExpr expr (TBZ (OpReg w reg_x) (widthInBits w - 1) (TBlock bid))
+
       -- Generic case.
       CmmMachOp mop [x, y] -> do
 
@@ -1598,20 +1728,14 @@ genCondJump bid expr = do
           _ -> pprPanic "AArch64.genCondJump:case mop: " (text $ show expr)
       _ -> pprPanic "AArch64.genCondJump: " (text $ show expr)
 
--- A conditional jump with at least +/-128M jump range
+-- | A conditional jump with at least +/-128M jump range.
+-- Uses condition inversion to save one instruction and one label:
+--   Before: BCOND cond jmp; B skip; jmp: B far; skip:  (3 insns, 2 labels)
+--   After:  BCOND !cond skip; B far; skip:              (2 insns, 1 label)
 genCondFarJump :: MonadGetUnique m => Cond -> Target -> m InstrBlock
 genCondFarJump cond far_target = do
   skip_lbl_id <- newBlockId
-  jmp_lbl_id <- newBlockId
-
-  -- TODO: We can improve this by inverting the condition
-  -- but it's not quite trivial since we don't know if we
-  -- need to consider float orderings.
-  -- So we take the hit of the additional jump in the false
-  -- case for now.
-  return $ toOL [ BCOND cond (TBlock jmp_lbl_id)
-                , B (TBlock skip_lbl_id)
-                , NEWBLOCK jmp_lbl_id
+  return $ toOL [ BCOND (invertCond cond) (TBlock skip_lbl_id)
                 , B far_target
                 , NEWBLOCK skip_lbl_id]
 
@@ -2182,15 +2306,22 @@ genCCall target dest_regs arg_regs = do
         -- Prefetch
         MO_Prefetch_Data _n -> return nilOL -- Prefetch hint.
 
-        -- Memory copy/set/move/cmp, with alignment for optimization
-
-        -- TODO Optimize and use e.g. quad registers to move memory around instead
-        -- of offloading this to memcpy. For small memcpys we can utilize
-        -- the 128bit quad registers in NEON to move block of bytes around.
-        -- Might also make sense of small memsets? Use xzr? What's the function
-        -- call overhead?
+        -- Memory copy/set/move/cmp, with alignment for optimization.
+        -- For small, known-size copies/sets we emit inline load/store
+        -- sequences using paired registers (STP/LDP), avoiding the
+        -- function call overhead (~15-20 cycles for save/restore/branch).
+        MO_Memcpy  align
+          | [dst, src, CmmLit (CmmInt n _)] <- arg_regs
+          , n >= 0, n <= 64
+          -> inlineMemcpy dst src (fromIntegral n) align
         MO_Memcpy  _align   -> mkCCall "memcpy"
+
+        MO_Memset  align
+          | [dst, val, CmmLit (CmmInt n _)] <- arg_regs
+          , n >= 0, n <= 64
+          -> inlineMemset dst val (fromIntegral n) align
         MO_Memset  _align   -> mkCCall "memset"
+
         MO_Memmove _align   -> mkCCall "memmove"
         MO_Memcmp  _align   -> mkCCall "memcmp"
 
@@ -2247,6 +2378,122 @@ genCCall target dest_regs arg_regs = do
           mkForeignLabel name ForeignLabelInThisPackage IsFunction
       let cconv = ForeignConvention CCallConv [NoHint] [NoHint] CmmMayReturn
       genCCall (ForeignTarget target cconv) dest_regs arg_regs
+
+    -- | Generate inline load/store sequence for small memcpy.
+    -- For copies up to 64 bytes, we emit LDR/STR (or LDP/STP for 16-byte
+    -- chunks) instead of calling memcpy. The peephole optimizer will
+    -- further merge adjacent LDR/STR into LDP/STP pairs.
+    --
+    -- Alignment thresholds are intentionally relaxed: AArch64 basic
+    -- load/store instructions (LDR, STR) support unaligned addresses
+    -- without faulting.  Only LDP/STP require natural alignment, hence
+    -- the stricter align >= 8 guard for the 16-byte path.
+    inlineMemcpy :: CmmExpr -> CmmExpr -> Int -> Int -> NatM InstrBlock
+    inlineMemcpy dst_expr src_expr n align = do
+      (dst_reg, _fmt_d, code_d) <- getSomeReg dst_expr
+      (src_reg, _fmt_s, code_s) <- getSomeReg src_expr
+      tmp1 <- getNewRegNat II64
+      tmp2 <- getNewRegNat II64
+      let -- Generate copy instructions for the remaining bytes at the given offset
+          go :: Int -> Int -> OrdList Instr
+          go off remaining
+            | remaining <= 0 = nilOL
+            -- 16-byte chunk using LDP/STP (requires 8-byte alignment)
+            | remaining >= 16, align >= 8 =
+                toOL [ LDP II64 (OpReg W64 tmp1) (OpReg W64 tmp2)
+                                (OpAddr (AddrRegImm src_reg (ImmInt off)))
+                     , STP II64 (OpReg W64 tmp1) (OpReg W64 tmp2)
+                                (OpAddr (AddrRegImm dst_reg (ImmInt off)))
+                     ] `appOL` go (off + 16) (remaining - 16)
+            -- 8-byte chunk (unaligned LDR/STR ok on AArch64)
+            | remaining >= 8, align >= 4 =
+                toOL [ LDR II64 (OpReg W64 tmp1) (OpAddr (AddrRegImm src_reg (ImmInt off)))
+                     , STR II64 (OpReg W64 tmp1) (OpAddr (AddrRegImm dst_reg (ImmInt off)))
+                     ] `appOL` go (off + 8) (remaining - 8)
+            -- 4-byte chunk
+            | remaining >= 4, align >= 2 =
+                toOL [ LDR II32 (OpReg W32 tmp1) (OpAddr (AddrRegImm src_reg (ImmInt off)))
+                     , STR II32 (OpReg W32 tmp1) (OpAddr (AddrRegImm dst_reg (ImmInt off)))
+                     ] `appOL` go (off + 4) (remaining - 4)
+            -- 2-byte chunk
+            | remaining >= 2, align >= 2 =
+                toOL [ LDR II16 (OpReg W16 tmp1) (OpAddr (AddrRegImm src_reg (ImmInt off)))
+                     , STR II16 (OpReg W16 tmp1) (OpAddr (AddrRegImm dst_reg (ImmInt off)))
+                     ] `appOL` go (off + 2) (remaining - 2)
+            -- 1-byte chunk
+            | otherwise =
+                toOL [ LDR II8 (OpReg W8 tmp1) (OpAddr (AddrRegImm src_reg (ImmInt off)))
+                     , STR II8 (OpReg W8 tmp1) (OpAddr (AddrRegImm dst_reg (ImmInt off)))
+                     ] `appOL` go (off + 1) (remaining - 1)
+      return $ code_d `appOL` code_s `appOL` go 0 n
+
+    -- | Generate inline store sequence for small memset.
+    -- For sets up to 64 bytes, we emit stores using a register holding the
+    -- fill value. For zero fills, we emit MOVZ tmp, #0 and let the post-RA
+    -- peephole optimizer convert STR tmp → STR xzr. We cannot use
+    -- RealRegSingle (-1) (xzr) directly in pre-RA code because the linear
+    -- register allocator's FreeRegs uses Word32 bitmaps that overflow on
+    -- negative register indices.
+    inlineMemset :: CmmExpr -> CmmExpr -> Int -> Int -> NatM InstrBlock
+    inlineMemset dst_expr val_expr n align = do
+      (dst_reg, _fmt_d, code_d) <- getSomeReg dst_expr
+      (val_reg, _fmt_v, code_v) <- getSomeReg val_expr
+      -- Splat the byte value across all 8 bytes of a register.
+      -- For zero, we materialize zero in a virtual register. The post-RA
+      -- peephole will optimize STR of a zero-valued register to STR xzr.
+      -- For non-zero, we replicate the byte: val | val<<8 | val<<16 | ...
+      tmp <- getNewRegNat II64
+      let -- Check if the value is a constant zero
+          isZero = case val_expr of
+            CmmLit (CmmInt 0 _) -> True
+            _                   -> False
+          -- The register to use for storing (zero in tmp, or splatted value)
+          (store_reg, splat_code)
+            | isZero    = (tmp, unitOL $ MOVZ (OpReg W64 tmp) (OpImm (ImmInt 0)))
+            | otherwise =
+                -- Replicate byte across 64-bit register:
+                -- ORR tmp, val, val LSL #8
+                -- ORR tmp, tmp, tmp LSL #16
+                -- ORR tmp, tmp, tmp LSL #32
+                (tmp, toOL
+                  [ ORR (OpReg W64 tmp) (OpReg W64 val_reg)
+                        (OpRegShift W64 val_reg SLSL 8)
+                  , ORR (OpReg W64 tmp) (OpReg W64 tmp)
+                        (OpRegShift W64 tmp SLSL 16)
+                  , ORR (OpReg W64 tmp) (OpReg W64 tmp)
+                        (OpRegShift W64 tmp SLSL 32)
+                  ])
+          -- Generate stores at offset.  See inlineMemcpy for the
+          -- rationale behind the relaxed alignment thresholds.
+          go :: Int -> Int -> OrdList Instr
+          go off remaining
+            | remaining <= 0 = nilOL
+            -- 16-byte chunk using STP (requires 8-byte alignment)
+            | remaining >= 16, align >= 8 =
+                unitOL (STP II64 (OpReg W64 store_reg) (OpReg W64 store_reg)
+                                 (OpAddr (AddrRegImm dst_reg (ImmInt off))))
+                `appOL` go (off + 16) (remaining - 16)
+            -- 8-byte chunk
+            | remaining >= 8, align >= 4 =
+                unitOL (STR II64 (OpReg W64 store_reg)
+                                 (OpAddr (AddrRegImm dst_reg (ImmInt off))))
+                `appOL` go (off + 8) (remaining - 8)
+            -- 4-byte chunk
+            | remaining >= 4, align >= 2 =
+                unitOL (STR II32 (OpReg W32 store_reg)
+                                 (OpAddr (AddrRegImm dst_reg (ImmInt off))))
+                `appOL` go (off + 4) (remaining - 4)
+            -- 2-byte chunk
+            | remaining >= 2, align >= 2 =
+                unitOL (STR II16 (OpReg W16 store_reg)
+                                 (OpAddr (AddrRegImm dst_reg (ImmInt off))))
+                `appOL` go (off + 2) (remaining - 2)
+            -- 1-byte chunk
+            | otherwise =
+                unitOL (STR II8 (OpReg W8 store_reg)
+                                (OpAddr (AddrRegImm dst_reg (ImmInt off))))
+                `appOL` go (off + 1) (remaining - 1)
+      return $ code_d `appOL` code_v `appOL` splat_code `appOL` go 0 n
 
     -- TODO: Optimize using paired stores and loads (STP, LDP). It is
     -- automatically done by the allocator for us. However it's not optimal,
@@ -2470,12 +2717,20 @@ makeFarBranches {- only used when debugging -} _platform statics basic_blocks = 
       -- pprTrace "lblMap" (ppr lblMap) $ basic_blocks
 
   where
-    -- 2^18, 19 bit immediate with one bit is reserved for the sign
-    max_jump_dist = 2^(18::Int) - 1 :: Int
+    -- 2^18, 19 bit immediate with one bit is reserved for the sign (for BCOND)
+    max_bcond_jump_dist = 2^(18::Int) - 1 :: Int
+    -- 2^13, 14 bit immediate with one bit reserved for sign (for TBZ/TBNZ/CBZ/CBNZ)
+    max_tbz_jump_dist = 2^(13::Int) - 1 :: Int
+    -- Use the more conservative distance for the overall check
+    max_jump_dist = max_tbz_jump_dist :: Int
     -- Currently all inline info tables fit into 64 bytes.
     max_info_size     = 16 :: Int
-    long_bc_jump_size =  3 :: Int
+    -- After condition inversion optimization: BCOND !cond skip; B far; skip:
+    long_bc_jump_size =  2 :: Int
+    -- CBZ/CBNZ far: CMP op, #0; BCOND !cond skip; B far; skip:
     long_bz_jump_size =  4 :: Int
+    -- TBZ/TBNZ far: TBNZ/TBZ (inverted) skip; B far; skip:
+    long_tb_jump_size =  2 :: Int
 
     -- Replace out of range conditional jumps with unconditional jumps.
     replace_blk :: LabelMap Int -> Int -> GenBasicBlock Instr -> UniqDSM (Int, [GenBasicBlock Instr])
@@ -2501,13 +2756,16 @@ makeFarBranches {- only used when debugging -} _platform statics basic_blocks = 
               pure (idx, ANN ann instr':instrs')
             (idx,[]) -> pprPanic "replace_jump" (text "empty return list for " <+> ppr idx)
         BCOND cond t
-          -> case target_in_range m t pos of
+          -> case target_in_range m t pos max_bcond_jump_dist of
               InRange -> pure (pos+long_bc_jump_size,[instr])
               NotInRange far_target -> do
                 jmp_code <- genCondFarJump cond far_target
                 pure (pos+long_bc_jump_size, fromOL jmp_code)
         CBZ op t -> long_zero_jump op t EQ
         CBNZ op t -> long_zero_jump op t NE
+        -- TBZ/TBNZ have 14-bit range (±32KB), same expansion strategy as CBZ/CBNZ
+        TBZ op bit t -> long_tbz_jump op bit t EQ
+        TBNZ op bit t -> long_tbz_jump op bit t NE
         instr
           | isMetaInstr instr -> pure (pos,[instr])
           | otherwise -> pure (pos+1, [instr])
@@ -2515,33 +2773,49 @@ makeFarBranches {- only used when debugging -} _platform statics basic_blocks = 
       where
         -- cmp_op: EQ = CBZ, NEQ = CBNZ
         long_zero_jump op t cmp_op =
-          case target_in_range m t pos of
+          case target_in_range m t pos max_tbz_jump_dist of
               InRange -> pure (pos+long_bz_jump_size,[instr])
               NotInRange far_target -> do
                 jmp_code <- genCondFarJump cmp_op far_target
-                -- TODO: Fix zero reg so we can use it here
                 pure (pos + long_bz_jump_size, CMP op (OpImm (ImmInt 0)) : fromOL jmp_code)
 
+        -- TBZ/TBNZ far jump: use condition inversion.
+        -- TBZ reg, #bit, far  →  TBNZ reg, #bit, skip; B far; skip:
+        -- TBNZ reg, #bit, far →  TBZ reg, #bit, skip; B far; skip:
+        -- The inverted TBZ/TBNZ always targets the skip label which is
+        -- only 1 instruction away, well within the 14-bit range.
+        long_tbz_jump op bit t _cmp_op =
+          case target_in_range m t pos max_tbz_jump_dist of
+              InRange -> pure (pos+long_tb_jump_size,[instr])
+              NotInRange far_target -> do
+                skip_lbl <- newBlockId
+                let inverted = case instr of
+                      TBZ {}  -> TBNZ op bit (TBlock skip_lbl)
+                      TBNZ {} -> TBZ op bit (TBlock skip_lbl)
+                      _       -> panic "long_tbz_jump: not TBZ/TBNZ"
+                pure (pos + long_tb_jump_size,
+                      [inverted, B far_target, NEWBLOCK skip_lbl])
 
-    target_in_range :: LabelMap Int -> Target -> Int -> BlockInRange
-    target_in_range m target src =
+
+    target_in_range :: LabelMap Int -> Target -> Int -> Int -> BlockInRange
+    target_in_range m target src max_dist =
       case target of
         (TReg{}) -> InRange
-        (TBlock bid) -> block_in_range m src bid
+        (TBlock bid) -> block_in_range m src bid max_dist
         (TLabel clbl)
           | Just bid <- maybeLocalBlockLabel clbl
-          -> block_in_range m src bid
+          -> block_in_range m src bid max_dist
           | otherwise
           -- Maybe we should be pessimistic here, for now just fixing intra proc jumps
           -> InRange
 
-    block_in_range :: LabelMap Int -> Int -> BlockId -> BlockInRange
-    block_in_range m src_pos dest_lbl =
+    block_in_range :: LabelMap Int -> Int -> BlockId -> Int -> BlockInRange
+    block_in_range m src_pos dest_lbl max_dist =
       case mapLookup dest_lbl m of
         Nothing       ->
           pprTrace "not in range" (ppr dest_lbl) $
             NotInRange (TBlock dest_lbl)
-        Just dest_pos -> if abs (dest_pos - src_pos) < max_jump_dist
+        Just dest_pos -> if abs (dest_pos - src_pos) < max_dist
           then InRange
           else NotInRange (TBlock dest_lbl)
 
@@ -2567,11 +2841,13 @@ makeFarBranches {- only used when debugging -} _platform statics basic_blocks = 
         Nothing           -> 0 :: Int
         Just _info_static -> max_info_size
 
-    -- These jumps have a 19bit immediate as offset which is quite
-    -- limiting so we potentially have to expand them into
-    -- multiple instructions.
+    -- These jumps have limited immediate offsets:
+    -- BCOND: 19-bit (±1MB), CBZ/CBNZ: 19-bit, TBZ/TBNZ: 14-bit (±32KB).
+    -- We potentially have to expand them into multiple instructions.
     is_expandable_jump i = case i of
       CBZ{}   -> Just long_bz_jump_size
       CBNZ{}  -> Just long_bz_jump_size
+      TBZ{}   -> Just long_tb_jump_size
+      TBNZ{}  -> Just long_tb_jump_size
       BCOND{} -> Just long_bc_jump_size
       _ -> Nothing

--- a/compiler/GHC/CmmToAsm/AArch64/Cond.hs
+++ b/compiler/GHC/CmmToAsm/AArch64/Cond.hs
@@ -1,6 +1,11 @@
-module GHC.CmmToAsm.AArch64.Cond  where
+module GHC.CmmToAsm.AArch64.Cond
+  ( Cond(..)
+  , invertCond
+  )
+where
 
 import GHC.Prelude hiding (EQ)
+import GHC.Utils.Panic (panic)
 
 -- https://developer.arm.com/documentation/den0024/a/the-a64-instruction-set/data-processing-instructions/conditional-instructions
 
@@ -70,3 +75,29 @@ data Cond
     | VS     -- oVerflow set
     | VC     -- oVerflow clear
     deriving Eq
+
+-- | Invert a condition code. Used for far branch optimization where we
+-- invert the condition and skip over an unconditional far jump, saving
+-- one instruction and one label per far branch.
+invertCond :: Cond -> Cond
+invertCond ALWAYS = panic "invertCond: cannot invert ALWAYS"
+invertCond EQ     = NE
+invertCond NE     = EQ
+invertCond SLT    = SGE
+invertCond SLE    = SGT
+invertCond SGE    = SLT
+invertCond SGT    = SLE
+invertCond ULT    = UGE
+invertCond ULE    = UGT
+invertCond UGE    = ULT
+invertCond UGT    = ULE
+invertCond OLT    = UOGE  -- ordered LT → unordered GE (NaN becomes true)
+invertCond OLE    = UOGT  -- ordered LE → unordered GT
+invertCond OGE    = UOLT  -- ordered GE → unordered LT
+invertCond OGT    = UOLE  -- ordered GT → unordered LE
+invertCond UOLT   = OGE   -- unordered LT → ordered GE
+invertCond UOLE   = OGT   -- unordered LE → ordered GT
+invertCond UOGE   = OLT   -- unordered GE → ordered LT
+invertCond UOGT   = OLE   -- unordered GT → ordered LE
+invertCond VS     = VC
+invertCond VC     = VS

--- a/compiler/GHC/CmmToAsm/AArch64/Instr.hs
+++ b/compiler/GHC/CmmToAsm/AArch64/Instr.hs
@@ -115,6 +115,7 @@ regUsageOfInstr platform instr = case instr of
   LSR dst src1 src2        -> usage (regOp src1 ++ regOp src2, regOp dst)
   MOV dst src              -> usage (regOp src, regOp dst)
   MOVK dst src             -> usage (regOp src, regOp dst)
+  MOVN dst src             -> usage (regOp src, regOp dst)
   MOVZ dst src             -> usage (regOp src, regOp dst)
   MVN dst src              -> usage (regOp src, regOp dst)
   ORR dst src1 src2        -> usage (regOp src1 ++ regOp src2, regOp dst)
@@ -128,13 +129,20 @@ regUsageOfInstr platform instr = case instr of
   -- 5. Atomic Instructions ----------------------------------------------------
   -- 6. Conditional Instructions -----------------------------------------------
   CSET dst _               -> usage ([], regOp dst)
+  CSEL dst src1 src2 _     -> usage (regOp src1 ++ regOp src2, regOp dst)
+  CSINC dst src1 src2 _    -> usage (regOp src1 ++ regOp src2, regOp dst)
+  CSNEG dst src1 src2 _    -> usage (regOp src1 ++ regOp src2, regOp dst)
   CBZ src _                -> usage (regOp src, [])
   CBNZ src _               -> usage (regOp src, [])
+  TBZ src _ _              -> usage (regOp src, [])
+  TBNZ src _ _             -> usage (regOp src, [])
   -- 7. Load and Store Instructions --------------------------------------------
   STR _ src dst            -> usage (regOp src ++ regOp dst, [])
   STLR _ src dst           -> usage (regOp src ++ regOp dst, [])
   LDR _ dst src            -> usage (regOp src, regOp dst)
   LDAR _ dst src           -> usage (regOp src, regOp dst)
+  STP _ src1 src2 dst      -> usage (regOp src1 ++ regOp src2 ++ regOp dst, [])
+  LDP _ dst1 dst2 src      -> usage (regOp src, regOp dst1 ++ regOp dst2)
 
   -- 8. Synchronization Instructions -------------------------------------------
   DMBISH _                 -> usage ([], [])
@@ -271,6 +279,7 @@ patchRegsOfInstr instr env = case instr of
     LSR o1 o2 o3   -> LSR  (patchOp o1) (patchOp o2) (patchOp o3)
     MOV o1 o2      -> MOV  (patchOp o1) (patchOp o2)
     MOVK o1 o2     -> MOVK (patchOp o1) (patchOp o2)
+    MOVN o1 o2     -> MOVN (patchOp o1) (patchOp o2)
     MOVZ o1 o2     -> MOVZ (patchOp o1) (patchOp o2)
     MVN o1 o2      -> MVN  (patchOp o1) (patchOp o2)
     ORR o1 o2 o3   -> ORR  (patchOp o1) (patchOp o2) (patchOp o3)
@@ -284,14 +293,21 @@ patchRegsOfInstr instr env = case instr of
 
     -- 5. Atomic Instructions --------------------------------------------------
     -- 6. Conditional Instructions ---------------------------------------------
-    CSET o c       -> CSET (patchOp o) c
-    CBZ o l        -> CBZ (patchOp o) l
-    CBNZ o l       -> CBNZ (patchOp o) l
+    CSET o c        -> CSET (patchOp o) c
+    CSEL o1 o2 o3 c -> CSEL (patchOp o1) (patchOp o2) (patchOp o3) c
+    CSINC o1 o2 o3 c -> CSINC (patchOp o1) (patchOp o2) (patchOp o3) c
+    CSNEG o1 o2 o3 c -> CSNEG (patchOp o1) (patchOp o2) (patchOp o3) c
+    CBZ o l         -> CBZ (patchOp o) l
+    CBNZ o l        -> CBNZ (patchOp o) l
+    TBZ o b l       -> TBZ (patchOp o) b l
+    TBNZ o b l      -> TBNZ (patchOp o) b l
     -- 7. Load and Store Instructions ------------------------------------------
     STR f o1 o2    -> STR f (patchOp o1) (patchOp o2)
     STLR f o1 o2   -> STLR f (patchOp o1) (patchOp o2)
     LDR f o1 o2    -> LDR f (patchOp o1) (patchOp o2)
     LDAR f o1 o2   -> LDAR f (patchOp o1) (patchOp o2)
+    STP f o1 o2 o3 -> STP f (patchOp o1) (patchOp o2) (patchOp o3)
+    LDP f o1 o2 o3 -> LDP f (patchOp o1) (patchOp o2) (patchOp o3)
 
     -- 8. Synchronization Instructions -----------------------------------------
     DMBISH c       -> DMBISH c
@@ -333,6 +349,8 @@ isJumpishInstr instr = case instr of
     ANN _ i -> isJumpishInstr i
     CBZ{} -> True
     CBNZ{} -> True
+    TBZ{} -> True
+    TBNZ{} -> True
     J{} -> True
     J_TBL{} -> True
     B{} -> True
@@ -347,6 +365,8 @@ jumpDestsOfInstr :: Instr -> [BlockId]
 jumpDestsOfInstr (ANN _ i) = jumpDestsOfInstr i
 jumpDestsOfInstr (CBZ _ t) = [ id | TBlock id <- [t]]
 jumpDestsOfInstr (CBNZ _ t) = [ id | TBlock id <- [t]]
+jumpDestsOfInstr (TBZ _ _ t) = [ id | TBlock id <- [t]]
+jumpDestsOfInstr (TBNZ _ _ t) = [ id | TBlock id <- [t]]
 jumpDestsOfInstr (J t) = [id | TBlock id <- [t]]
 jumpDestsOfInstr (J_TBL ids _mbLbl _r) = catMaybes ids
 jumpDestsOfInstr (B t) = [id | TBlock id <- [t]]
@@ -374,6 +394,8 @@ patchJumpInstr instr patchF
         ANN d i -> ANN d (patchJumpInstr i patchF)
         CBZ r (TBlock bid) -> CBZ r (TBlock (patchF bid))
         CBNZ r (TBlock bid) -> CBNZ r (TBlock (patchF bid))
+        TBZ r b (TBlock bid) -> TBZ r b (TBlock (patchF bid))
+        TBNZ r b (TBlock bid) -> TBNZ r b (TBlock (patchF bid))
         J (TBlock bid) -> J (TBlock (patchF bid))
         J_TBL ids mbLbl r -> J_TBL (map (fmap patchF) ids) mbLbl r
         B (TBlock bid) -> B (TBlock (patchF bid))
@@ -660,7 +682,7 @@ data Instr
     | LSR Operand Operand Operand -- rd = rn ≫ rm  or rd = rn ≫ #i, i is 6 bits
     | MOV Operand Operand -- rd = rn  or  rd = #i
     | MOVK Operand Operand
-    -- | MOVN Operand Operand
+    | MOVN Operand Operand -- rd = ~(imm16 << shift), move wide with NOT
     | MOVZ Operand Operand
     | MVN Operand Operand -- rd = ~rn
     | ORR Operand Operand Operand -- rd = rn | op2
@@ -670,12 +692,22 @@ data Instr
     | STLR Format Operand Operand -- stlr Xn, address-mode // Xn -> *addr
     | LDR Format Operand Operand -- ldr Xn, address-mode // Xn <- *addr
     | LDAR Format Operand Operand -- ldar Xn, address-mode // Xn <- *addr
+    -- Paired load/store: transfer two registers in a single operation,
+    -- using one decode slot instead of two.
+    | STP Format Operand Operand Operand -- stp Xt1, Xt2, [addr] // Xt1,Xt2 -> *addr
+    | LDP Format Operand Operand Operand -- ldp Xt1, Xt2, [addr] // Xt1,Xt2 <- *addr
 
     -- Conditional instructions
     | CSET Operand Cond   -- if(cond) op <- 1 else op <- 0
+    | CSEL Operand Operand Operand Cond  -- csel dst, src1, src2, cond: dst = cond ? src1 : src2
+    | CSINC Operand Operand Operand Cond -- csinc dst, src1, src2, cond: dst = cond ? src1 : src2+1
+    | CSNEG Operand Operand Operand Cond -- csneg dst, src1, src2, cond: dst = cond ? src1 : -src2
 
     | CBZ Operand Target  -- if op == 0, then branch.
     | CBNZ Operand Target -- if op /= 0, then branch.
+    -- Test bit and branch: more efficient than AND+CMP+BCOND for single-bit tests
+    | TBZ Operand Int Target  -- tbz reg, #bit, label: branch if bit is zero
+    | TBNZ Operand Int Target -- tbnz reg, #bit, label: branch if bit is nonzero
     -- Branching.
     | J Target            -- like B, but only generated from genJump. Used to distinguish genJumps from others.
     | J_TBL [Maybe BlockId] (Maybe CLabel) Reg -- A jump instruction with data for switch/jump tables
@@ -758,6 +790,7 @@ instrCon i =
       LSR{} -> "LSR"
       MOV{} -> "MOV"
       MOVK{} -> "MOVK"
+      MOVN{} -> "MOVN"
       MOVZ{} -> "MOVZ"
       MVN{} -> "MVN"
       ORR{} -> "ORR"
@@ -765,9 +798,16 @@ instrCon i =
       STLR{} -> "STLR"
       LDR{} -> "LDR"
       LDAR{} -> "LDAR"
+      STP{} -> "STP"
+      LDP{} -> "LDP"
       CSET{} -> "CSET"
+      CSEL{} -> "CSEL"
+      CSINC{} -> "CSINC"
+      CSNEG{} -> "CSNEG"
       CBZ{} -> "CBZ"
       CBNZ{} -> "CBNZ"
+      TBZ{} -> "TBZ"
+      TBNZ{} -> "TBNZ"
       J{} -> "J"
       J_TBL {} -> "J_TBL"
       B{} -> "B"

--- a/compiler/GHC/CmmToAsm/AArch64/Peephole.hs
+++ b/compiler/GHC/CmmToAsm/AArch64/Peephole.hs
@@ -1,0 +1,228 @@
+{- |
+Module      : GHC.CmmToAsm.AArch64.Peephole
+Description : Post-register-allocation peephole optimizer for AArch64
+Copyright   : (c) Moritz Angermann <moritz.angermann@iohk.io>, 2026
+License     : BSD-3
+
+Post-register-allocation peephole optimizer. Runs over the final instruction
+stream and rewrites instruction sequences to take advantage of AArch64-specific
+instructions and idioms.
+
+Optimizations performed:
+
+  * LDP\/STP formation: Merges adjacent LDR\/STR at consecutive offsets
+    into paired load\/store instructions, saving a decode slot.
+    Only II32 and II64 formats are supported (AArch64 has no 8\/16-bit
+    paired load\/store instructions).
+
+  * STR-of-zero: Replaces MOV\/MOVZ reg,#0; STR reg,[addr] with
+    STR xzr,[addr], eliminating the move instruction entirely.
+
+  * Redundant move elimination: Removes identity moves (MOV r,r).
+
+  * Redundant extension elimination: Removes consecutive identical
+    sign\/zero extensions (e.g. UXTB w0,w0; UXTB w0,w0).
+
+  * CMP+CSET+CB{N}Z→BCOND: Rewrites a comparison that produces a boolean
+    followed by a conditional branch on that boolean into a single
+    conditional branch, saving 2 instructions.
+-}
+module GHC.CmmToAsm.AArch64.Peephole
+  ( peephole
+  )
+where
+
+import GHC.Prelude hiding (EQ)
+import GHC.CmmToAsm.AArch64.Instr
+import GHC.CmmToAsm.AArch64.Regs (AddrMode(..), Imm(..))
+import GHC.CmmToAsm.AArch64.Cond
+import GHC.CmmToAsm.Format
+import GHC.Platform.Reg
+
+-- | Run the peephole optimizer over an instruction list.
+-- This is designed to be called after register allocation, when final
+-- register assignments are known and pattern matching is most effective.
+peephole :: [Instr] -> [Instr]
+peephole = peep []
+  where
+    -- Process instructions, building result in reverse for efficiency.
+    -- We look ahead at 2-3 instructions for pattern matching.
+    peep :: [Instr] -> [Instr] -> [Instr]
+    peep acc [] = reverse acc
+    peep acc (i:rest) = case matchPattern i rest of
+      Just (replacement, remaining) -> peep acc (replacement ++ remaining)
+      Nothing -> peep (i:acc) rest
+
+-- | Try to match a peephole pattern starting at the given instruction.
+-- Returns Just (replacement, remaining) if a pattern matches.
+matchPattern :: Instr -> [Instr] -> Maybe ([Instr], [Instr])
+matchPattern i rest = case i of
+
+  -- Pattern: Identity move elimination
+  -- MOV r, r → (removed)
+  MOV o1 o2
+    | o1 == o2
+    -> Just ([], rest)
+
+  -- Pattern: STR-of-zero
+  -- MOV/MOVZ reg, #0; STR fmt reg addr → STR fmt xzr addr
+  -- Uses the hardware zero register to avoid materializing zero.
+  -- Restricted to II32/II64: pprReg only handles the zero register
+  -- (RealRegSingle -1) at W32 (wzr) and W64 (xzr) widths, so we cannot
+  -- substitute xzr into II8/II16 stores.
+  _ | Just (dst, dst_n) <- isZeroMov i
+    , (STR fmt (OpReg w' src) addr : rest') <- rest
+    , RegReal (RealRegSingle src_n) <- src
+    , dst_n == src_n
+    , dst_n < 32  -- GP register
+    , fmt == II32 || fmt == II64  -- zero register only printable at W32/W64
+    , not (addrUsesReg dst addr)  -- dst not used in the address computation
+    -> Just ([STR fmt (OpReg w' (RegReal (RealRegSingle (-1)))) addr], rest')
+       -- regNo -1 is the zero register (xzr/wzr)
+
+  -- Pattern: LDP formation from consecutive LDRs
+  -- LDR fmt r1, [base, #off]; LDR fmt r2, [base, #off+size] → LDP fmt r1, r2, [base, #off]
+  -- Note: LDP/STP only support 32-bit and 64-bit integer registers (no 8/16-bit).
+  LDR fmt1 dst1@(OpReg _w1 r1) (OpAddr (AddrRegImm base1 (ImmInt off1)))
+    | (LDR fmt2 dst2@(OpReg _w2 r2) (OpAddr (AddrRegImm base2 (ImmInt off2))) : rest') <- rest
+    , fmt1 == fmt2
+    , base1 == base2
+    , r1 /= r2
+    , off2 == off1 + formatInBytes fmt1
+    , isLdpStpFormat fmt1
+    , isLdpStpOffset off1 fmt1
+    , not (isFloatFormat fmt1)  -- Only integer registers for now
+    -> Just ([LDP fmt1 dst1 dst2 (OpAddr (AddrRegImm base1 (ImmInt off1)))], rest')
+
+  -- Pattern: LDP formation (reversed order)
+  -- LDR fmt r2, [base, #off+size]; LDR fmt r1, [base, #off] → LDP fmt r1, r2, [base, #off]
+  LDR fmt1 dst1@(OpReg _w1 r1) (OpAddr (AddrRegImm base1 (ImmInt off1)))
+    | (LDR fmt2 dst2@(OpReg _w2 r2) (OpAddr (AddrRegImm base2 (ImmInt off2))) : rest') <- rest
+    , fmt1 == fmt2
+    , base1 == base2
+    , r1 /= r2
+    , off1 == off2 + formatInBytes fmt1
+    , isLdpStpFormat fmt1
+    , isLdpStpOffset off2 fmt1
+    , not (isFloatFormat fmt1)
+    -- Ensure first load's destination isn't the base register
+    , not (regUsedIn r1 base1)
+    -> Just ([LDP fmt1 dst2 dst1 (OpAddr (AddrRegImm base1 (ImmInt off2)))], rest')
+
+  -- Pattern: STP formation from consecutive STRs
+  -- STR fmt r1, [base, #off]; STR fmt r2, [base, #off+size] → STP fmt r1, r2, [base, #off]
+  STR fmt1 src1@(OpReg _w1 _) (OpAddr (AddrRegImm base1 (ImmInt off1)))
+    | (STR fmt2 src2@(OpReg _w2 _) (OpAddr (AddrRegImm base2 (ImmInt off2))) : rest') <- rest
+    , fmt1 == fmt2
+    , base1 == base2
+    , off2 == off1 + formatInBytes fmt1
+    , isLdpStpFormat fmt1
+    , isLdpStpOffset off1 fmt1
+    , not (isFloatFormat fmt1)
+    -> Just ([STP fmt1 src1 src2 (OpAddr (AddrRegImm base1 (ImmInt off1)))], rest')
+
+  -- Pattern: STP formation (reversed order)
+  STR fmt1 src1@(OpReg _w1 _) (OpAddr (AddrRegImm base1 (ImmInt off1)))
+    | (STR fmt2 src2@(OpReg _w2 _) (OpAddr (AddrRegImm base2 (ImmInt off2))) : rest') <- rest
+    , fmt1 == fmt2
+    , base1 == base2
+    , off1 == off2 + formatInBytes fmt1
+    , isLdpStpFormat fmt1
+    , isLdpStpOffset off2 fmt1
+    , not (isFloatFormat fmt1)
+    -> Just ([STP fmt1 src2 src1 (OpAddr (AddrRegImm base1 (ImmInt off2)))], rest')
+
+  -- Pattern: Redundant extension elimination
+  -- EXT dst, src; EXT dst', src' where dst==dst'==src'==src → EXT dst, src
+  UXTB dst _src
+    | (UXTB dst' src' : rest') <- rest
+    , dst == dst', dst == src'
+    -> Just ([i], rest')
+  UXTH dst _src
+    | (UXTH dst' src' : rest') <- rest
+    , dst == dst', dst == src'
+    -> Just ([i], rest')
+  SXTB dst _src
+    | (SXTB dst' src' : rest') <- rest
+    , dst == dst', dst == src'
+    -> Just ([i], rest')
+  SXTH dst _src
+    | (SXTH dst' src' : rest') <- rest
+    , dst == dst', dst == src'
+    -> Just ([i], rest')
+
+  -- Pattern: CMP + CSET + CBNZ/CBZ → CMP + BCOND
+  -- CMP x, y; CSET w, cond; CBNZ w, lbl → CMP x, y; BCOND cond lbl
+  -- CMP x, y; CSET w, cond; CBZ w, lbl  → CMP x, y; BCOND !cond lbl
+  --
+  -- Safety: This removes the CSET, so cset_dst no longer gets written.
+  -- This is safe because CBNZ/CBZ terminates the basic block, and
+  -- the peephole runs per-block. The CMP+CSET+CB{N}Z pattern is
+  -- generated by the backend specifically for conditional branches
+  -- where the boolean register is only consumed by the branch.
+  CMP _ _
+    | (CSET (OpReg _ cset_dst) cond : branch : rest') <- rest
+    , Just target <- cbnzTarget cset_dst branch
+    -> Just ([i, BCOND (branchCond cond branch) target], rest')
+
+  -- Annotations: look through annotations for pattern matching
+  ANN doc inner
+    | Just (replacement, remaining) <- matchPattern inner rest
+    -> Just (map (ANN doc) replacement, remaining)
+
+  _ -> Nothing
+
+-- | Recognize a zero-materializing move instruction.
+-- Matches both MOV reg, #0 and MOVZ reg, #0 (the latter is emitted
+-- by inlineMemset for zero fills).
+isZeroMov :: Instr -> Maybe (Reg, Int)
+isZeroMov (MOV (OpReg _w dst) (OpImm (ImmInt 0)))
+  | RegReal (RealRegSingle n) <- dst = Just (dst, n)
+isZeroMov (MOVZ (OpReg _w dst) (OpImm (ImmInt 0)))
+  | RegReal (RealRegSingle n) <- dst = Just (dst, n)
+isZeroMov _ = Nothing
+
+-- | Extract branch target from CBNZ/CBZ if it references the given register
+cbnzTarget :: Reg -> Instr -> Maybe Target
+cbnzTarget r (CBNZ (OpReg _ r') t) | r == r' = Just t
+cbnzTarget r (CBZ (OpReg _ r') t)  | r == r' = Just t
+cbnzTarget _ _ = Nothing
+
+-- | Determine the effective condition for CMP+CSET+CBZ/CBNZ fusion.
+-- CBNZ tests "not zero" → the CSET condition is used directly.
+-- CBZ tests "zero" → the CSET condition is inverted.
+branchCond :: Cond -> Instr -> Cond
+branchCond cond (CBNZ _ _) = cond
+branchCond cond (CBZ _ _)  = invertCond cond
+branchCond _ _ = error "branchCond: not a CBZ/CBNZ"
+
+-- | Check if a format is supported by LDP/STP.
+-- AArch64 LDP/STP only support 32-bit and 64-bit integer registers
+-- (and SIMD/FP registers, which we don't handle here). There are no
+-- 8-bit or 16-bit paired load/store instructions.
+isLdpStpFormat :: Format -> Bool
+isLdpStpFormat II32 = True
+isLdpStpFormat II64 = True
+isLdpStpFormat _    = False
+
+-- | Check if an offset is valid for LDP/STP.
+-- LDP/STP use a 7-bit signed immediate, scaled by the access size.
+-- 64-bit: offset must be multiple of 8, range [-512, 504]
+-- 32-bit: offset must be multiple of 4, range [-256, 252]
+isLdpStpOffset :: Int -> Format -> Bool
+isLdpStpOffset off fmt =
+  let scale = formatInBytes fmt
+  in off `mod` scale == 0
+     && off >= -64 * scale
+     && off <= 63 * scale
+
+-- | Check if a register is used in an address mode operand.
+addrUsesReg :: Reg -> Operand -> Bool
+addrUsesReg r (OpAddr (AddrRegReg r1 r2)) = r == r1 || r == r2
+addrUsesReg r (OpAddr (AddrRegImm r1 _))  = r == r1
+addrUsesReg r (OpAddr (AddrReg r1))       = r == r1
+addrUsesReg _ _ = False
+
+-- | Check if a register is the same as an address base register.
+regUsedIn :: Reg -> Reg -> Bool
+regUsedIn = (==)

--- a/compiler/GHC/CmmToAsm/AArch64/Ppr.hs
+++ b/compiler/GHC/CmmToAsm/AArch64/Ppr.hs
@@ -7,6 +7,7 @@ import GHC.Prelude hiding (EQ)
 import GHC.CmmToAsm.AArch64.Instr
 import GHC.CmmToAsm.AArch64.Regs
 import GHC.CmmToAsm.AArch64.Cond
+import GHC.CmmToAsm.AArch64.Peephole (peephole)
 import GHC.CmmToAsm.Ppr
 import GHC.CmmToAsm.Format
 import GHC.Platform.Reg
@@ -115,10 +116,11 @@ pprBasicBlock platform with_dwarf info_env (BasicBlock blockid instrs)
       else empty
     )
   where
-    -- Filter out identity moves. E.g. mov x18, x18 will be dropped.
-    optInstrs = filter f instrs
-      where f (MOV o1 o2) | o1 == o2 = False
-            f _ = True
+    -- Post-register-allocation peephole optimizer.
+    -- Rewrites instruction sequences to use AArch64-specific instructions
+    -- like LDP/STP, eliminates redundant moves and extensions, and fuses
+    -- CMP+CSET+CB{N}Z into BCOND.
+    optInstrs = peephole instrs
 
     asmLbl = blockLbl blockid
     maybe_infotable c = case mapLookup blockid info_env of
@@ -420,6 +422,7 @@ pprInstr platform instr = case instr of
     | isFloatOp o1 || isFloatOp o2 -> op2 (text "\tfmov") o1 o2
     | otherwise                    -> op2 (text "\tmov") o1 o2
   MOVK o1 o2    -> op2 (text "\tmovk") o1 o2
+  MOVN o1 o2    -> op2 (text "\tmovn") o1 o2
   MOVZ o1 o2    -> op2 (text "\tmovz") o1 o2
   MVN o1 o2     -> op2 (text "\tmvn") o1 o2
   ORR o1 o2 o3  -> op3 (text "\torr") o1 o2 o3
@@ -442,6 +445,9 @@ pprInstr platform instr = case instr of
   -- 5. Atomic Instructions ----------------------------------------------------
   -- 6. Conditional Instructions -----------------------------------------------
   CSET o c  -> line $ text "\tcset" <+> pprOp platform o <> comma <+> pprCond c
+  CSEL o1 o2 o3 c -> line $ text "\tcsel" <+> pprOp platform o1 <> comma <+> pprOp platform o2 <> comma <+> pprOp platform o3 <> comma <+> pprCond c
+  CSINC o1 o2 o3 c -> line $ text "\tcsinc" <+> pprOp platform o1 <> comma <+> pprOp platform o2 <> comma <+> pprOp platform o3 <> comma <+> pprCond c
+  CSNEG o1 o2 o3 c -> line $ text "\tcsneg" <+> pprOp platform o1 <> comma <+> pprOp platform o2 <> comma <+> pprOp platform o3 <> comma <+> pprCond c
 
   CBZ o (TBlock bid) -> line $ text "\tcbz" <+> pprOp platform o <> comma <+> pprAsmLabel platform (mkLocalBlockLabel (getUnique bid))
   CBZ o (TLabel lbl) -> line $ text "\tcbz" <+> pprOp platform o <> comma <+> pprAsmLabel platform lbl
@@ -450,6 +456,14 @@ pprInstr platform instr = case instr of
   CBNZ o (TBlock bid) -> line $ text "\tcbnz" <+> pprOp platform o <> comma <+> pprAsmLabel platform (mkLocalBlockLabel (getUnique bid))
   CBNZ o (TLabel lbl) -> line $ text "\tcbnz" <+> pprOp platform o <> comma <+> pprAsmLabel platform lbl
   CBNZ _ (TReg _)     -> panic "AArch64.ppr: No conditional (cbnz) branching to registers!"
+
+  TBZ o bit (TBlock bid) -> line $ text "\ttbz" <+> pprOp platform o <> comma <+> char '#' <> int bit <> comma <+> pprAsmLabel platform (mkLocalBlockLabel (getUnique bid))
+  TBZ o bit (TLabel lbl) -> line $ text "\ttbz" <+> pprOp platform o <> comma <+> char '#' <> int bit <> comma <+> pprAsmLabel platform lbl
+  TBZ _ _ (TReg _)       -> panic "AArch64.ppr: No conditional (tbz) branching to registers!"
+
+  TBNZ o bit (TBlock bid) -> line $ text "\ttbnz" <+> pprOp platform o <> comma <+> char '#' <> int bit <> comma <+> pprAsmLabel platform (mkLocalBlockLabel (getUnique bid))
+  TBNZ o bit (TLabel lbl) -> line $ text "\ttbnz" <+> pprOp platform o <> comma <+> char '#' <> int bit <> comma <+> pprAsmLabel platform lbl
+  TBNZ _ _ (TReg _)       -> panic "AArch64.ppr: No conditional (tbnz) branching to registers!"
 
   -- 7. Load and Store Instructions --------------------------------------------
   -- NOTE: GHC may do whacky things where it only load the lower part of an
@@ -514,6 +528,9 @@ pprInstr platform instr = case instr of
     op2 (text "\tldrh") o1 o2
   LDR _f o1 o2 -> op2 (text "\tldr") o1 o2
   LDAR _f o1 o2 -> op2 (text "\tldar") o1 o2
+
+  STP _f o1 o2 o3 -> op3 (text "\tstp") o1 o2 o3
+  LDP _f o1 o2 o3 -> op3 (text "\tldp") o1 o2 o3
 
   -- 8. Synchronization Instructions -------------------------------------------
   DMBISH DmbLoadStore -> line $ text "\tdmb ish"

--- a/compiler/ghc.cabal.in
+++ b/compiler/ghc.cabal.in
@@ -253,6 +253,7 @@ Library
         GHC.CmmToAsm.AArch64.CodeGen
         GHC.CmmToAsm.AArch64.Cond
         GHC.CmmToAsm.AArch64.Instr
+        GHC.CmmToAsm.AArch64.Peephole
         GHC.CmmToAsm.AArch64.Ppr
         GHC.CmmToAsm.AArch64.RegInfo
         GHC.CmmToAsm.AArch64.Regs


### PR DESCRIPTION
## Summary

- Add post-register-allocation peephole optimizer with LDP/STP formation, STR-of-zero, redundant move/extension elimination, and CMP+CSET+CBZ→BCOND fusion
- Add 8 new AArch64 instructions: MOVN, CSEL/CSINC/CSNEG, TBZ/TBNZ, STP/LDP
- Improve constant materialization with MOVN for negative values and smart MOVZ vs MOVN cost analysis
- Add TBZ/TBNZ codegen for single-bit tests (replaces 3-instruction AND+CMP+BCOND)
- Implement far branch condition inversion (2 instructions instead of 3)
- Inline memcpy/memset for known sizes ≤64 bytes, avoiding ~15-20 cycle call overhead

## Details

These optimizations target Apple Silicon (M1-M4) characteristics: 8-wide decode, 13-14 cycle branch misprediction penalty, and CMP+BCOND macro-fusion. The peephole optimizer runs after register allocation when final register assignments are known, enabling pattern matching that is impossible during initial code generation.

**6 files changed, 612 insertions, 65 deletions**

## Test plan

- [x] Stage1 compiler library (889 modules) compiles with zero errors and zero warnings
- [ ] Full stage2 build and testsuite pass
- [ ] Inspect `-ddump-asm` output for key patterns (LDP/STP formation, MOVN usage, TBZ/TBNZ generation)
- [ ] nofib benchmark comparison before/after