### PR TITLE
Normalise LLVM target triple for Apple platforms (aarch64 -> arm64)

### DIFF
--- a/utils/ghc-toolchain/exe/Main.hs
+++ b/utils/ghc-toolchain/exe/Main.hs
@@ -33,7 +33,7 @@ import GHC.Toolchain.Tools.Ranlib
 import GHC.Toolchain.Tools.Nm
 import GHC.Toolchain.Tools.MergeObjs
 import GHC.Toolchain.Tools.Readelf
-import GHC.Toolchain.NormaliseTriple (normaliseTriple)
+import GHC.Toolchain.NormaliseTriple (normaliseTriple, normaliseLlvmTarget)
 import Text.Read (readMaybe)
 
 data Opts = Opts
@@ -440,8 +440,9 @@ ldOverrideWhitelist a =
 mkTarget :: Opts -> M Target
 mkTarget opts = do
     normalised_triple <- normaliseTriple (fromMaybe (error "missing --triple") (optTriple opts))
-    -- Use Llvm target if specified, otherwise use triple as llvm target
-    let tgtLlvmTarget = fromMaybe normalised_triple (optLlvmTriple opts)
+    -- Use Llvm target if specified, otherwise use triple as llvm target.
+    -- Normalise for platform conventions (e.g. aarch64-apple-* -> arm64-apple-*).
+    let tgtLlvmTarget = normaliseLlvmTarget $ fromMaybe normalised_triple (optLlvmTriple opts)
 
     (archOs, tgtVendor) <- do
       cc0 <- findBasicCc (optCc opts)

--- a/utils/ghc-toolchain/src/GHC/Toolchain/NormaliseTriple.hs
+++ b/utils/ghc-toolchain/src/GHC/Toolchain/NormaliseTriple.hs
@@ -1,8 +1,12 @@
-module GHC.Toolchain.NormaliseTriple where
+module GHC.Toolchain.NormaliseTriple
+  ( normaliseTriple
+  , normaliseLlvmTarget
+  ) where
 
 import GHC.Toolchain.Prelude
 import GHC.Toolchain.Program
 import Data.Text (strip, pack, unpack)
+import Data.List (isPrefixOf)
 
 -- | Normalise the triple by calling `config.sub` on the given triple.
 normaliseTriple :: String -> M String
@@ -11,3 +15,18 @@ normaliseTriple triple = do
   normalised_triple <- norm <$> readProgramStdout shProgram ["config.sub", triple]
   logInfo $ unwords ["Normalised triple:", triple, "~>", normalised_triple]
   return normalised_triple
+
+-- | Normalise the LLVM target triple for platform conventions.
+--
+-- Apple's LLVM toolchain uses @arm64@ as the canonical architecture name
+-- for AArch64 on Apple platforms, while GNU config.sub normalises to
+-- @aarch64@. This mismatch causes problems with toolchain wrappers (e.g.
+-- nix cc-wrapper) that do string comparison on the @--target@ flag.
+--
+-- See also: the @llvm-targets@ file uses @arm64-apple-darwin@.
+normaliseLlvmTarget :: String -> String
+normaliseLlvmTarget triple
+  | "aarch64-apple-" `isPrefixOf` triple
+  = "arm64-" ++ drop (length "aarch64-") triple
+  | otherwise
+  = triple


### PR DESCRIPTION
## Summary

- Add `normaliseLlvmTarget` to `ghc-toolchain` that rewrites `aarch64-apple-*` to `arm64-apple-*` in LLVM target triples
- GNU `config.sub` normalises to `aarch64-apple-darwin`, but Apple's LLVM toolchain and nix's cc-wrapper expect `arm64-apple-darwin`
- Without this fix, GHC passes `--target=aarch64-apple-darwin` to clang, triggering a cc-wrapper warning that pollutes stderr and causes ~5400/10775 testsuite failures on aarch64-darwin

Split out from #149 (the HADRIAN_SETTINGS removal was already merged separately).

## Test plan

- [ ] CI passes on x86_64-linux (no regression)
- [ ] aarch64-darwin builds should no longer produce cc-wrapper `--target` mismatch warnings