### PR TITLE
fix: use _build/dist for CI artifacts and test target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,23 +57,23 @@ jobs:
       shell: devx {0}
       run: cabal update
 
-    # The Makefile will run configure (and boot 😞), we also need to create a
-    # synthetic package before running configure.  Once this nuissance is fixed
+    # The Makefile will run configure (and boot), we also need to create a
+    # synthetic package before running configure.  Once this nuisance is fixed
     # we can do proper configure + make again. Until then... we have to live
     # with the hack of running everything from the make target.
     # - name: Configure the build
     #   shell: devx {0}
     #   run: ./configure
 
-    - name: Build the bindist (dynamic=${{ matrix.dynamic }})
+    - name: Build (dynamic=${{ matrix.dynamic }})
       shell: devx {0}
       run: make DYNAMIC=${{ matrix.dynamic }}
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.plat }}-dynamic${{ matrix.dynamic }}-bindist
-        path: _build/bindist
+        name: ${{ matrix.plat }}-dynamic${{ matrix.dynamic }}-dist
+        path: _build/dist
 
     - name: Run the testsuite (dynamic=${{ matrix.dynamic }})
       shell: devx {0}

--- a/Makefile
+++ b/Makefile
@@ -648,10 +648,10 @@ stage2: $(GHC1) $(CABAL) $(CONFIGURE_SCRIPTS) $(CONFIGURED_FILES) cabal.project.
 	@for binary in $(DIST_DIR)/bin/* ; do \
 		$(call SET_RPATH,../lib/$(HOST_PLATFORM),$${binary}) ; \
 	done
+ifeq ($(DYNAMIC),1)
 ifneq ($(UNAME), Darwin)
 	$(PATCHELF) --force-rpath --set-rpath "\$$ORIGIN" $(CURDIR)/$(DIST_DIR)/lib/$(TARGET_PLATFORM)/$(DLL)
 endif
-ifeq ($(DYNAMIC),1)
 	$(call LOG,Create -dyn iserv executable symlink so ghc can find ghc-iserv-dyn)
 	@$(LN_SF) ghc-iserv$(EXE_EXT) "$(DIST_DIR)/bin/ghc-iserv-dyn$(EXE_EXT)"
 endif
@@ -1043,8 +1043,10 @@ export SKIP_PERF_TESTS
 
 # --- Test Suite Helper Tool Paths & Flags (Hadrian parity light) ---
 # We approximate Hadrian's test invocation without depending on Hadrian.
-# Bindist places test tools in $(BUILD_DIR)/bindist/bin (created by the bindist target).
-TEST_TOOLS_DIR := $(BUILD_DIR)/bindist/bin
+# $(CURDIR) is needed because the test recipe runs $(MAKE) -C testsuite/tests,
+# so relative paths would resolve from the wrong directory. This matters both
+# for CI and local `make test` invocations.
+TEST_TOOLS_DIR := $(CURDIR)/$(DIST_DIR)/bin
 TEST_GHC       := $(TEST_TOOLS_DIR)/ghc
 TEST_GHC_PKG   := $(TEST_TOOLS_DIR)/ghc-pkg
 TEST_HP2PS     := $(TEST_TOOLS_DIR)/hp2ps
@@ -1065,7 +1067,7 @@ testsuite-timeout:
 
 # --- Test Target ---
 
-test: $(BUILD_DIR)/bindist testsuite-timeout
+test: stage2 testsuite-timeout
 	@echo "::group::Running tests with THREADS=$(THREADS)" >&2
 	# If any required tool is missing, testsuite logic will skip related tests.
 	TEST_HC='$(TEST_GHC)' \


### PR DESCRIPTION
## Summary

Fixes fallout from #140 (New Makefile build system) where `_build/bindist` was renamed to `_build/dist` but `ci.yml` and the Makefile test infrastructure were not updated.

- **ci.yml**: upload `_build/dist` instead of nonexistent `_build/bindist`
- **Makefile**: `TEST_TOOLS_DIR` points at `$(DIST_DIR)/bin` with absolute path (needed for `make -C` in testsuite)
- **Makefile**: `test` target depends on `stage2` (which creates `_build/dist`)
- **Makefile**: guard `patchelf` `.so` rpath patching with `DYNAMIC=1` — static builds produce no shared libraries, so the glob `*.so` fails

## Test plan

- [ ] devx CI dynamic=0 should no longer fail on patchelf
- [ ] devx CI dynamic=1 should no longer fail on missing `_build/bindist`
- [ ] `make test` should work after `make` completes