### PR TITLE
fix: address julian-review findings for metrics code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     #   run: ./configure
 
     - name: Start metrics collection
-      shell: bash
+      shell: bash  # bash (not devx): metrics tools use absolute paths to system binaries
       run: ./mk/collect-metrics.sh start _build/metrics 0.5
 
     - name: Build (dynamic=${{ matrix.dynamic }})
@@ -99,7 +99,7 @@ jobs:
 
     - name: Stop metrics collection
       if: ${{ !cancelled() }}
-      shell: bash
+      shell: bash  # bash (not devx): metrics tools use absolute paths to system binaries
       run: ./mk/collect-metrics.sh stop _build/metrics
 
     - name: Display test timings

--- a/mk/collect-metrics.sh
+++ b/mk/collect-metrics.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # collect-metrics.sh - Collect CPU and memory metrics during build
 #
-# Usage: collect-metrics.sh start METRICS_DIR [INTERVAL]
+# Bash dependency: uses bash features (<<<, [[ ]], local) — bash is
+# guaranteed in CI where this script runs (GitHub Actions, Hydra).
+#
+# Usage: collect-metrics.sh start [METRICS_DIR] [INTERVAL]
 #        collect-metrics.sh stop
 #
 # Commands:
@@ -9,7 +12,7 @@
 #   stop    - Stop metrics collection
 #
 # Arguments:
-#   METRICS_DIR - Directory for metrics output
+#   METRICS_DIR - Directory for metrics output (default: _build/metrics)
 #   INTERVAL    - Sample interval in seconds (default: 0.5)
 #
 # Output files:
@@ -28,118 +31,159 @@ METRICS_FILE="$METRICS_DIR/metrics.csv"
 # Detect OS for platform-specific commands
 OS="$(uname -s)"
 
-# State file for CPU delta calculation
-CPU_STATE_FILE=""
+# State file for CPU delta calculation (Linux only).
+# Format: '$total $idle' (two space-separated integers from /proc/stat).
+# Initialized here so the path is visible at the top of the script;
+# run_collector() clears the file before the first sample.
+CPU_STATE_FILE="$METRICS_DIR/.cpu_state"
 
-# Get CPU usage percentage (cross-platform)
-# Calculates delta between samples for accurate instantaneous usage
+# ---------------------------------------------------------------------------
+# CPU helpers
+# ---------------------------------------------------------------------------
+
+# macOS: sum per-process CPU usage via ps.
+# kern.cp_time is FreeBSD-only and doesn't exist on macOS, so we fall
+# back to aggregating per-process values.
+# Use absolute path — nix devx shell may not include /bin in PATH.
+# Use POSIX 'pcpu' keyword (not '%cpu') for portability.
+# NR>1 skips the header line that ps prints.
+get_cpu_usage_darwin() {
+    /bin/ps -A -o pcpu 2>/dev/null \
+        | awk 'NR>1 {sum += $1} END {printf "%.1f", sum}' \
+        || { echo "Error: ps -A -o pcpu failed" >&2; exit 1; }
+}
+
+# Linux: calculate from /proc/stat with delta.
+# /proc/stat format:
+#   cpu  <user> <nice> <system> <idle> <iowait> <irq> <softirq> [steal] [guest] [guest_nice]
+get_cpu_usage_linux() {
+    # Guard: /proc/stat may be absent in minimal containers (e.g. scratch
+    # Docker images without procfs mounted).  Fail loudly — if we can't
+    # sample CPU, the metrics are useless and the CI job should notice.
+    if [[ ! -f /proc/stat ]]; then
+        echo "Error: /proc/stat not found (procfs not mounted?)" >&2
+        exit 1
+    fi
+
+    local line
+    read -r line < /proc/stat
+
+    # Parse fields — use named variable for label instead of _ (special bash variable).
+    # /proc/stat has 10 numeric fields; we only need the first 7 for CPU calculation.
+    # The 'rest' variable captures any additional fields (steal, guest, guest_nice).
+    local label user nice sys idle iowait irq softirq rest
+    read label user nice sys idle iowait irq softirq rest <<< "$line"
+
+    # Validate we got numeric values (guards against parse failures)
+    if [[ -z "$user" || -z "$idle" ]]; then
+        echo "Error: failed to parse /proc/stat" >&2
+        exit 1
+    fi
+
+    local total=$((user + nice + sys + idle + iowait + irq + softirq))
+
+    if [[ -f "$CPU_STATE_FILE" ]]; then
+        local prev_total prev_idle
+        read prev_total prev_idle < "$CPU_STATE_FILE"
+        local delta_total=$((total - prev_total))
+        local delta_idle=$((idle - prev_idle))
+        if [[ $delta_total -gt 0 ]]; then
+            echo "$total $idle" > "$CPU_STATE_FILE"
+            awk "BEGIN {printf \"%.1f\", 100 * (1 - $delta_idle / $delta_total)}"
+            return
+        fi
+    fi
+
+    echo "$total $idle" > "$CPU_STATE_FILE"
+    if [[ $total -gt 0 ]]; then
+        awk "BEGIN {printf \"%.1f\", 100 * (1 - $idle / $total)}"
+    else
+        echo "Error: /proc/stat total CPU time is zero" >&2
+        exit 1
+    fi
+}
+
+# Get CPU usage percentage (cross-platform).
+# Dispatches to the platform-specific helper.
+# Prints CPU usage percentage (float) to stdout.
 get_cpu_usage() {
     case "$OS" in
-        Darwin)
-            # macOS: sum per-process CPU usage via ps
-            # Note: kern.cp_time is FreeBSD-only and doesn't exist on macOS.
-            # Use absolute path — nix devx shell may not include /bin in PATH.
-            /bin/ps -A -o %cpu 2>/dev/null \
-                | awk '{sum += $1} END {printf "%.1f", sum}' \
-                || echo "0.0"
-            ;;
-        Linux)
-            # Linux: calculate from /proc/stat with delta
-            # /proc/stat format: cpu  <user> <nice> <system> <idle> <iowait> <irq> <softirq> [steal] [guest] [guest_nice]
-            if [[ ! -f /proc/stat ]]; then
-                echo "0"
-                return
-            fi
-
-            local line
-            read -r line < /proc/stat
-
-            # Parse fields - use named variable for label instead of _ (special bash variable)
-            # Note: /proc/stat has 10 numeric fields; we only need the first 7 for CPU calculation
-            # The 'rest' variable captures any additional fields (steal, guest, guest_nice)
-            local label user nice sys idle iowait irq softirq rest
-            read label user nice sys idle iowait irq softirq rest <<< "$line"
-
-            # Validate we got numeric values (guards against parse failures)
-            if [[ -z "$user" || -z "$idle" ]]; then
-                echo "0"
-                return
-            fi
-
-            local total=$((user + nice + sys + idle + iowait + irq + softirq))
-
-            if [[ -f "$CPU_STATE_FILE" ]]; then
-                local prev_total prev_idle
-                read prev_total prev_idle < "$CPU_STATE_FILE"
-                local delta_total=$((total - prev_total))
-                local delta_idle=$((idle - prev_idle))
-                if [[ $delta_total -gt 0 ]]; then
-                    echo "$total $idle" > "$CPU_STATE_FILE"
-                    awk "BEGIN {printf \"%.1f\", 100 * (1 - $delta_idle / $delta_total)}"
-                    return
-                fi
-            fi
-
-            echo "$total $idle" > "$CPU_STATE_FILE"
-            if [[ $total -gt 0 ]]; then
-                awk "BEGIN {printf \"%.1f\", 100 * (1 - $idle / $total)}"
-            else
-                echo "0"
-            fi
-            ;;
-        *)
-            echo "0"
-            ;;
+        Darwin) get_cpu_usage_darwin ;;
+        Linux)  get_cpu_usage_linux  ;;
+        *)      echo "Error: unsupported OS '$OS' for CPU metrics" >&2; exit 1 ;;
     esac
 }
 
-# Get memory usage in MB (cross-platform)
+# ---------------------------------------------------------------------------
+# Memory helpers
+# ---------------------------------------------------------------------------
+
+# macOS: use vm_stat and sysctl with absolute paths.
+# Nix devx shell may not include /usr/bin or /usr/sbin in PATH.
+# Prints used_mb,total_mb to stdout.
+get_memory_usage_darwin() {
+    local page_size total_mb
+    page_size=$(/usr/sbin/sysctl -n hw.pagesize 2>/dev/null) \
+        || { echo "Error: sysctl hw.pagesize failed" >&2; exit 1; }
+    total_mb=$(( $(/usr/sbin/sysctl -n hw.memsize 2>/dev/null \
+        || { echo "Error: sysctl hw.memsize failed" >&2; exit 1; }) / 1024 / 1024 ))
+
+    # Parse vm_stat output — use $NF (last field) so the varying label
+    # column count doesn't matter.
+    # The '+ 0' strips the trailing period that vm_stat appends to each
+    # numeric value (e.g. "1234." becomes 1234).
+    /usr/bin/vm_stat 2>/dev/null \
+        | awk -v ps="$page_size" -v total="$total_mb" '
+            /Pages active/                { active     = $NF + 0 }
+            /Pages wired/                 { wired      = $NF + 0 }
+            /Pages stored in compressor/  { compressed = $NF + 0 }
+            END {
+                used_mb = int((active + wired + compressed) * ps / 1024 / 1024)
+                printf "%d,%d", used_mb, total
+            }
+        ' \
+        || { echo "Error: vm_stat failed" >&2; exit 1; }
+}
+
+# Linux: parse /proc/meminfo.
+# Prints used_mb,total_mb to stdout.
+get_memory_usage_linux() {
+    if [[ ! -f /proc/meminfo ]]; then
+        echo "Error: /proc/meminfo not found (procfs not mounted?)" >&2
+        exit 1
+    fi
+
+    awk '
+        /^MemTotal:/ { total = $2 }
+        /^MemAvailable:/ { available = $2 }
+        END {
+            total_mb = int(total / 1024)
+            used_mb = int((total - available) / 1024)
+            printf "%d,%d", used_mb, total_mb
+        }
+    ' /proc/meminfo \
+        || { echo "Error: failed to parse /proc/meminfo" >&2; exit 1; }
+}
+
+# Get memory usage in MB (cross-platform).
+# Dispatches to the platform-specific helper.
+# Prints used_mb,total_mb (CSV integers) to stdout.
 get_memory_usage() {
     case "$OS" in
-        Darwin)
-            # macOS: use vm_stat and sysctl with absolute paths
-            # Nix devx shell may not include /usr/bin or /usr/sbin in PATH.
-            page_size=$(/usr/sbin/sysctl -n hw.pagesize 2>/dev/null || echo 4096)
-            total_mb=$(( $(/usr/sbin/sysctl -n hw.memsize 2>/dev/null || echo 0) / 1024 / 1024 ))
-
-            # Parse vm_stat output — use $NF (last field) for robustness across
-            # macOS versions (the label column count varies, e.g. "Pages compressed"
-            # vs "Pages stored in compressor").
-            /usr/bin/vm_stat 2>/dev/null | awk -v ps="$page_size" -v total="$total_mb" '
-                /Pages active/                { active     = $NF + 0 }
-                /Pages wired/                 { wired      = $NF + 0 }
-                /Pages stored in compressor/  { compressed = $NF + 0 }
-                /Pages compressed/            { compressed = $NF + 0 }
-                END {
-                    used_mb = int((active + wired + compressed) * ps / 1024 / 1024)
-                    printf "%d,%d", used_mb, total
-                }
-            '
-            ;;
-        Linux)
-            # Linux: parse /proc/meminfo
-            awk '
-                /^MemTotal:/ { total = $2 }
-                /^MemAvailable:/ { available = $2 }
-                END {
-                    total_mb = int(total / 1024)
-                    used_mb = int((total - available) / 1024)
-                    printf "%d,%d", used_mb, total_mb
-                }
-            ' /proc/meminfo
-            ;;
-        *)
-            echo "0,0"
-            ;;
+        Darwin) get_memory_usage_darwin ;;
+        Linux)  get_memory_usage_linux  ;;
+        *)      echo "Error: unsupported OS '$OS' for memory metrics" >&2; exit 1 ;;
     esac
 }
 
+# ---------------------------------------------------------------------------
 # Collector loop
+# ---------------------------------------------------------------------------
+
 run_collector() {
     mkdir -p "$METRICS_DIR"
 
-    # Initialize CPU state file for delta calculations
-    CPU_STATE_FILE="$METRICS_DIR/.cpu_state"
+    # Clear any stale CPU state from a previous run
     rm -f "$CPU_STATE_FILE"
 
     # Write CSV header
@@ -154,6 +198,10 @@ run_collector() {
         sleep "$INTERVAL"
     done
 }
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 case "$CMD" in
     start)
@@ -177,6 +225,8 @@ case "$CMD" in
     stop)
         if [[ -f "$PID_FILE" ]]; then
             pid=$(cat "$PID_FILE")
+            # SIGTERM is sufficient — the collector is a simple sleep loop
+            # with no signal handlers or cleanup requirements.
             if kill "$pid" 2>/dev/null; then
                 echo "Stopped metrics collector (PID: $pid)"
             else
@@ -189,7 +239,7 @@ case "$CMD" in
         ;;
 
     *)
-        echo "Usage: $0 start METRICS_DIR [INTERVAL]"
+        echo "Usage: $0 start [METRICS_DIR] [INTERVAL]"
         echo "       $0 stop"
         exit 1
         ;;

--- a/mk/plot-metrics.py
+++ b/mk/plot-metrics.py
@@ -23,8 +23,9 @@ Two separate plots are generated:
 import sys
 import os
 import csv
+import colorsys
 import hashlib
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 # Try to import matplotlib, provide helpful error if not available
@@ -39,6 +40,23 @@ except ImportError:
     print("  nix run nixpkgs#python3Packages.matplotlib -- mk/plot-metrics.py ...")
     print("  # or: pip install matplotlib")
     sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Data pipeline overview
+#
+# The script processes metrics in five stages:
+#
+#   1. COLLECT  — mk/collect-metrics.sh samples CPU% and memory at a fixed
+#                 interval and writes rows to metrics.csv.
+#   2. READ     — read_metrics() / read_phases() parse the CSV and the
+#                 per-phase .start/.end timestamp files into lists.
+#   3. SELECT   — select_display_phases() decides which phases to render:
+#                 sub-phases replace their parent when available.
+#   4. FILTER   — filter_metrics_for_phases() trims the time-series to the
+#                 window covered by the selected phases (±30 s margin).
+#   5. PLOT     — create_plot() renders a dual-axis (CPU + memory) SVG with
+#                 phase shading and labels.
+# ---------------------------------------------------------------------------
 
 
 def read_metrics(metrics_file):
@@ -116,34 +134,20 @@ def format_duration(seconds):
         return f"{hours}h {mins}m"
 
 
-def _hex_to_rgb(hex_color):
-    """Convert '#RRGGBB' to (r, g, b) floats in [0,1]."""
-    h = hex_color.lstrip('#')
-    return tuple(int(h[i:i+2], 16) / 255.0 for i in (0, 2, 4))
-
-
-def _rgb_to_hex(r, g, b):
-    """Convert (r, g, b) floats in [0,1] to '#RRGGBB'."""
-    return '#{:02x}{:02x}{:02x}'.format(
-        int(min(max(r, 0), 1) * 255),
-        int(min(max(g, 0), 1) * 255),
-        int(min(max(b, 0), 1) * 255),
-    )
-
-
 def _vary_color(hex_color, index, total):
     """Generate a color variation for sub-phase `index` of `total`.
 
-    Shifts lightness up/down symmetrically around the base color so that
-    adjacent sub-phases are visually distinct.
+    Shifts HLS lightness up/down symmetrically around the base color so
+    that adjacent sub-phases are visually distinct.
     """
     if total <= 1:
         return hex_color
-    r, g, b = _hex_to_rgb(hex_color)
+    r, g, b = matplotlib.colors.to_rgb(hex_color)
+    h, l, s = colorsys.rgb_to_hls(r, g, b)
     # Spread from -0.15 to +0.15 lightness shift
     t = (index / (total - 1)) - 0.5  # [-0.5, 0.5]
-    shift = t * 0.30
-    return _rgb_to_hex(r + shift, g + shift, b + shift)
+    l = min(max(l + t * 0.30, 0.0), 1.0)
+    return matplotlib.colors.to_hex(colorsys.hls_to_rgb(h, l, s))
 
 
 # Top-level build phase names (and prefixes for stage3-*)
@@ -226,14 +230,36 @@ def _display_label(name):
 
 
 def create_plot(timestamps, cpu, mem_used, mem_total, phases, title, output_file):
-    """Create a single metrics plot for the given data and phases."""
+    """Create a dual-axis metrics plot and save it as SVG.
+
+    Left y-axis:  CPU usage (%) — on multi-core machines CPU can exceed
+                  100%, so the axis scales to ``effective_cores * 100``.
+    Right y-axis: Memory used (GB).
+
+    Each phase is drawn as a translucent shaded region with a dashed
+    vertical line at its start.  Labels alternate between two y-positions
+    (top / slightly below top) so that narrow adjacent phases don't
+    overlap each other's text.
+
+    Args:
+        timestamps: list[datetime]   — sample times.
+        cpu:        list[float]      — CPU percentage per sample.
+        mem_used:   list[float]      — used memory in MB per sample.
+        mem_total:  list[float]      — total memory in MB per sample.
+        phases:     list of (name, start, end, status) tuples.
+        title:      str              — plot title text.
+        output_file: str             — destination path (SVG).
+    """
     cpu_color = '#2E86AB'  # Blue
     mem_color = '#28A745'  # Green
 
     # Create figure with dual y-axes — wider aspect ratio (20:6)
     fig, ax1 = plt.subplots(figsize=(20, 6))
 
-    # Calculate effective concurrency from max CPU usage
+    # On multi-core machines ps / /proc/stat report aggregate CPU%, so a
+    # 4-core box fully loaded reads ~400%.  We derive the effective core
+    # count from the peak value and scale the y-axis to cores*100 so the
+    # chart fills the available space without clipping.
     max_cpu = max(cpu) if cpu else 100
     effective_cores = int((max_cpu + 99) // 100)  # ceil(max_cpu / 100)
     cpu_limit = effective_cores * 100
@@ -258,8 +284,11 @@ def create_plot(timestamps, cpu, mem_used, mem_total, phases, title, output_file
         max_mem_gb = max(mem_total) / 1024
         ax2.set_ylim(0, max_mem_gb * 1.1)
 
-    # Assign colors to phases — sub-phases get variations of their parent color
-    # Group sub-phases by parent to assign variation indices
+    # Assign colors to phases.  Sub-phases inherit their parent's base
+    # color (_base_color_for) and get a lightness variation via
+    # _vary_color() so that e.g. stage2.rts / stage2.libraries /
+    # stage2.executables are visually distinct yet clearly related.
+    # Top-level phases without sub-phases use the base color directly.
     parent_groups = {}
     for name, _, _, _ in phases:
         parent = _parent_of(name)
@@ -295,8 +324,10 @@ def create_plot(timestamps, cpu, mem_used, mem_total, phases, title, output_file
             # Add vertical line at phase start
             ax1.axvline(x=start, color=color, linestyle='--', linewidth=1, alpha=0.7)
 
-            # Label positioning — alternate top/bottom for adjacent sub-phases
-            # to prevent overlap when phases are narrow
+            # Label positioning — alternate between two y-positions (top of
+            # chart vs slightly below) for even/odd phase indices.  This
+            # prevents text overlap when consecutive phases are narrow and
+            # their labels would otherwise sit on top of each other.
             mid_time = start + (end - start) / 2
             duration = int((end - start).total_seconds())
             duration_str = format_duration(duration)
@@ -308,7 +339,7 @@ def create_plot(timestamps, cpu, mem_used, mem_total, phases, title, output_file
                 va = 'top'
             else:
                 y_pos = cpu_limit * 0.88
-                va = 'top'
+                va = 'bottom'
 
             ax1.annotate(
                 f'{label}\n{duration_str} {status_marker}',
@@ -351,7 +382,6 @@ def filter_metrics_for_phases(timestamps, cpu, mem_used, mem_total, phases):
     phase_end = max(p[2] for p in phases)
 
     # Add some margin (30 seconds before and after)
-    from datetime import timedelta
     margin = timedelta(seconds=30)
     range_start = phase_start - margin
     range_end = phase_end + margin


### PR DESCRIPTION
## Summary

- **collect-metrics.sh**: Use POSIX `pcpu` (not `%cpu`), skip ps header, warn on unsupported OS, declare locals, document output formats and awk idioms
- **plot-metrics.py**: Replace custom hex/rgb helpers with `matplotlib.colors`/`colorsys` builtins, fix `va='top'` copy-paste bug, move `timedelta` import to top-level
- **ci.yml**: Add inline comments explaining why metrics steps use `shell: bash`

## Test plan

- [x] `bash -n mk/collect-metrics.sh` passes
- [x] `python3 -c "import ast; ast.parse(open('mk/plot-metrics.py').read())"` passes
- [ ] CI build succeeds (metrics collection + plot generation)