### PR TITLE
rts: remove orphaned FP_VISIBILITY_HIDDEN from configure.ac

### DIFF
--- a/rts/configure.ac
+++ b/rts/configure.ac
@@ -207,8 +207,6 @@ if test "$CABAL_FLAG_leading_underscore" = 1; then
    AC_DEFINE([LEADING_UNDERSCORE], [1], [Define to 1 if C symbols have a leading underscore added by the compiler.])
 fi
 
-FP_VISIBILITY_HIDDEN
-
 FP_MUSTTAIL
 
 dnl ** check for librt


### PR DESCRIPTION
## Summary

- Remove orphaned `FP_VISIBILITY_HIDDEN` call from `rts/configure.ac`
- The macro definition was removed in an earlier commit, leaving a dangling call that triggers autoconf warnings

## Test plan

- [ ] Verify `./configure` runs without `FP_VISIBILITY_HIDDEN` warnings