### PR TITLE
Switch Cabal to wip/angerman/compile-less (cross-compile + local store + recompilation avoidance)

### DIFF
--- a/cabal.project.stage0
+++ b/cabal.project.stage0
@@ -1,7 +1,7 @@
 source-repository-package
   type: git
   location: https://github.com/stable-haskell/Cabal.git
-  tag: d7bf2ce3f9a7da4640833ddc5bb7740d2557b6a7
+  tag: 44817477ff6d22de4bfa4307e061df58f319d3b6
   subdir: Cabal
           Cabal-syntax
           cabal-install

--- a/cabal.project.stage1
+++ b/cabal.project.stage1
@@ -45,7 +45,7 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/stable-haskell/Cabal.git
-  tag: d7bf2ce3f9a7da4640833ddc5bb7740d2557b6a7
+  tag: 44817477ff6d22de4bfa4307e061df58f319d3b6
   subdir: Cabal
           Cabal-syntax
 

--- a/cabal.project.stage2
+++ b/cabal.project.stage2
@@ -84,11 +84,11 @@ packages:
   https://hackage.haskell.org/package/happy-2.1.5/happy-2.1.5.tar.gz
   https://hackage.haskell.org/package/happy-lib-2.1.5/happy-lib-2.1.5.tar.gz
 
--- wip/andrea/local-store
+-- wip/angerman/compile-less (cross-compilation + local store + recompilation avoidance)
 source-repository-package
   type: git
   location: https://github.com/stable-haskell/Cabal.git
-  tag: d7bf2ce3f9a7da4640833ddc5bb7740d2557b6a7
+  tag: 44817477ff6d22de4bfa4307e061df58f319d3b6
   subdir: Cabal
           Cabal-syntax
 

--- a/cabal.project.stage3
+++ b/cabal.project.stage3
@@ -67,7 +67,7 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/stable-haskell/Cabal.git
-  tag: d7bf2ce3f9a7da4640833ddc5bb7740d2557b6a7
+  tag: 44817477ff6d22de4bfa4307e061df58f319d3b6
   subdir: Cabal
           Cabal-syntax
 


### PR DESCRIPTION
## Summary

- Switches all stage cabal.project files to `stable-haskell/cabal` branch `wip/angerman/compile-less` (`44817477ff6d22de4bfa4307e061df58f319d3b6`)
- This branch is based on Andrea Bedini's `wip/andrea/compile-less` plus cherry-picks from hasufell and the TOCTOU race fix

## What's included in the new Cabal branch

**From `wip/andrea/compile-less`:**
- Cross-compilation support (Stage/Toolchain architecture, solver scoping, dual compilers)
- Local store (replaces in-place builds with project-local store)
- Recompilation avoidance (reinstated file monitor tracking for installed packages)
- Dead compiler removal (NHC, YHC, Hugs, GHCJS, etc.)
- Extensive solver refactoring and error handling improvements

**Cherry-picked from `wip/hasufell/compile-less`:**
- `137c9812d` — Stop stealing the vowels
- `b576cdb49` — Fix caching of remote source tarballs

**Cherry-picked from `fix/unpack-toctou-race-minimal`:**
- `d7bf2ce3f` → `44817477f` — Serialise BuildInplaceOnly tarball extraction to prevent TOCTOU race (conflict-resolved to preserve both the TOCTOU lock and the recompilation avoidance `BuildStatusConfigure MonitorFirstRun` call)

## Test plan

- [ ] CI passes (stage0 → stage1 → stage2 build)
- [ ] Verify recompilation avoidance works (incremental rebuilds don't recompile unchanged packages)
- [ ] Verify TOCTOU race is fixed (concurrent stage builds don't corrupt tarball extraction)