### PR TITLE
Fix CI failures from updated runner images (deriveConstants, ld warnings)

### DIFF
--- a/libraries/ghc-internal/src/GHC/Internal/System/Posix/Internals.hs
+++ b/libraries/ghc-internal/src/GHC/Internal/System/Posix/Internals.hs
@@ -97,7 +97,11 @@ data {-# CTYPE "struct stat" #-}  CStat
 data {-# CTYPE "struct termios" #-} CTermios
 data {-# CTYPE "struct tm" #-} CTm
 data {-# CTYPE "struct tms" #-} CTms
+#if defined(mingw32_HOST_OS)
+data {-# CTYPE "struct _utimbuf" #-} CUtimbuf
+#else
 data {-# CTYPE "struct utimbuf" #-} CUtimbuf
+#endif
 data {-# CTYPE "struct utsname" #-} CUtsname
 
 type FD = CInt

--- a/testsuite/driver/testlib.py
+++ b/testsuite/driver/testlib.py
@@ -3061,6 +3061,8 @@ def normalise_errmsg(s: str) -> str:
     s = re.sub('ld: warning: -sdk_version and -platform_version are not compatible, ignoring -sdk_version','',s)
     # ignore superfluous dylibs passed to the linker.
     s = re.sub('ld: warning: .*, ignoring unexpected dylib file\n','',s)
+    # ignore macOS ld warning about reexported libraries (e.g. Homebrew llvm libunwind)
+    s = re.sub('ld: warning: reexported library with install name .* couldn.t be matched with any parent library and will be linked directly\n','',s)
     # ignore LLVM Version mismatch garbage; this will just break tests.
     s = re.sub('You are using an unsupported version of LLVM!.*\n','',s)
     s = re.sub('Currently only [\\.0-9]+ is supported. System LLVM version: [\\.0-9]+.*\n','',s)
@@ -3175,6 +3177,8 @@ def normalise_output( s: str ) -> str:
     s = re.sub('ld: warning: -sdk_version and -platform_version are not compatible, ignoring -sdk_version','',s)
     # ignore superfluous dylibs passed to the linker.
     s = re.sub('ld: warning: .*, ignoring unexpected dylib file\n','',s)
+    # ignore macOS ld warning about reexported libraries (e.g. Homebrew llvm libunwind)
+    s = re.sub('ld: warning: reexported library with install name .* couldn.t be matched with any parent library and will be linked directly\n','',s)
     # ignore LLVM Version mismatch garbage; this will just break tests.
     s = re.sub('You are using an unsupported version of LLVM!.*\n','',s)
     s = re.sub('Currently only [\\.0-9]+ is supported. System LLVM version: [\\.0-9]+.*\n','',s)

--- a/utils/deriveConstants/Main.hs
+++ b/utils/deriveConstants/Main.hs
@@ -137,7 +137,10 @@ parseArgs = do args <- getArgs
           f opts ("-o" : fn : args')
               = f (opts {o_outputFilename = Just fn}) args'
           f opts ("--gcc-program" : prog : args')
-              = f (opts {o_gccProg = Just prog}) args'
+              = case words prog of
+                  (p:flags) -> f (opts {o_gccProg = Just p,
+                                        o_gccFlags = flags ++ o_gccFlags opts}) args'
+                  []        -> f (opts {o_gccProg = Just prog}) args'
           f opts ("--gcc-flag" : flag : args')
               = f (opts {o_gccFlags = flag : o_gccFlags opts}) args'
           f opts ("--nm-program" : prog : args')


### PR DESCRIPTION
## Summary

Fixes CI build/test failures caused by updated GitHub Actions runner images.

- **deriveConstants: split CC flags from program path** — Recent macOS and Windows runner images set `CC` to `"/usr/bin/cc -std=gnu23"`. `deriveConstants` passed the entire string to `rawSystem` as an executable path, failing on Mac x86_64, Mac aarch64, and Windows.
- **ghc-internal: use `struct _utimbuf` on Windows** — With `-std=gnu23`, clang on MSYS2/CLANG64 now errors on the type mismatch between `struct utimbuf` (POSIX) and `struct _utimbuf` (Windows `_utime` parameter). Use the correct Windows type name in the CTYPE pragma.
- **testsuite: normalise macOS ld reexported library warning** — The macOS-13 runner now ships Homebrew `llvm@18`, whose `libunwind` triggers a linker warning on every `ld` invocation, causing ~190 spurious test stderr mismatches on `Test binary (Mac x86_64)`.

## Test plan

- [ ] Mac x86_64, Mac aarch64, and Windows builds succeed
- [ ] `Test binary (Mac x86_64)` passes (reexported library warning filtered)
- [ ] Windows `ghc-internal` compiles without `-Wincompatible-pointer-types` error