### PR TITLE
fix: make cabal.project.stage1 hermetic (:none + pin happy/alex/hpc)

### DIFF
--- a/cabal.project.stage1
+++ b/cabal.project.stage1
@@ -1,6 +1,15 @@
 -- Configuration common to all stages
 import: cabal.project.common
 
+-- Hermetic build: resolve only from the explicitly-listed packages (+ the
+-- bootstrap compiler's installed packages), never Hackage. stage2/stage3
+-- already set this, but stage1 did not — so stage1's build-tools (happy/alex
+-- for the compiler's Parser.y/Lexer.x) floated to Hackage's newest. That was
+-- latent until happy-2.1.7 was published, after which stage1 built
+-- happy-lib-2.1.7 and the resulting parser code broke the build
+-- (genprimopcode GHC-44432: happyDoParse vs the pinned happy template).
+active-repositories: :none
+
 packages:
   -- NOTE: we need rts-headers, because the _newly_ built compiler depends
   --       on these potentially _new_ headers, we must not rely on those from
@@ -40,6 +49,15 @@ packages:
   https://hackage.haskell.org/package/semaphore-compat-2.0.1/semaphore-compat-2.0.1.tar.gz
   https://hackage.haskell.org/package/unix-2.8.8.0/unix-2.8.8.0.tar.gz
   https://hackage.haskell.org/package/Win32-2.14.2.1/Win32-2.14.2.1.tar.gz
+
+  -- Build-tools for the compiler's Parser.y / Lexer.x, plus hpc (a dep of ghc
+  -- whose bootstrap-installed version wants the old directory). Pinned so the
+  -- `active-repositories: :none` above resolves them to the same vetted
+  -- versions as stage2/stage3 instead of floating to Hackage's newest.
+  https://hackage.haskell.org/package/alex-3.5.2.0/alex-3.5.2.0.tar.gz
+  https://hackage.haskell.org/package/happy-2.1.5/happy-2.1.5.tar.gz
+  https://hackage.haskell.org/package/happy-lib-2.1.5/happy-lib-2.1.5.tar.gz
+  https://hackage.haskell.org/package/hpc-0.7.0.2/hpc-0.7.0.2.tar.gz
   -- hsc2hs: see source-repository-package below
 
 source-repository-package


### PR DESCRIPTION
## Make `cabal.project.stage1` hermetic

stage1 was missing `active-repositories: :none` and an explicit build-tool pin,
while **stage2 and stage3 both have them**. So stage1's build-tools —
happy/happy-lib/alex for the compiler's `Parser.y` / `Lexer.x` — resolved from
Hackage and floated to the newest version.

This was **latent**: it only broke once **happy-2.1.7** was published upstream.
After that, stage1 resolved + built `happy-lib-2.1.7`, whose generated parser
uses `happyDoParse`, which mismatches the pinned 2.1.5 happy template and fails
to compile (`genprimopcode`, `GHC-44432: happyDoParse … lacks an accompanying
binding`). CI that had been green started failing across platforms with **no
source change** — purely the upstream happy release. It also leaks into the
wasm/JS cross stage3, where the build-stage `genprimopcode` picks up the same
floated happy.

### Fix
Give stage1 the same hermeticity as stage2/stage3: `active-repositories: :none`
+ explicit `alex-3.5.2.0` / `happy-2.1.5` / `happy-lib-2.1.5` / `hpc-0.7.0.2`
URLs (versions match the other stages). `hpc` is a dependency of `ghc` whose
bootstrap-installed version wants the old `directory`, conflicting with the
pinned `directory-1.3.10.0`, so it must be provided as source too.

### Validation
Verified on the modern-pin branch: with this change stage1's solver plans
happy-2.1.5 (not 2.1.7) and stage1 + stage2 `genprimopcode` build cleanly
(`happyParse`, no `GHC-44432`).

> NOTE: `stable-ghc-9.14`'s own CI is separately broken — its stage* cabal pin
> is the branch name `stable-haskell/master` (not a SHA), which doesn't resolve.
> That's pre-existing and unrelated to this one-file hermeticity fix.
