### PR TITLE
rts: also pass THREADED_RTS via -optc for Cmm in threaded ways

### DIFF
--- a/rts/rts.cabal
+++ b/rts/rts.cabal
@@ -673,7 +673,7 @@ common rts-debug-flags
 common rts-threaded-flags
     ghc-options: -DTHREADED_RTS -optc-DTHREADED_RTS
     cpp-options: -DTHREADED_RTS
-    cmm-options: -DTHREADED_RTS
+    cmm-options: -DTHREADED_RTS -optc-DTHREADED_RTS
     cc-options:  -DTHREADED_RTS
 
 -- the _main_ library needs to deal with all the _configure_ time stuff.


### PR DESCRIPTION
The rts-threaded-flags stanza set THREADED_RTS four ways, but none reached the C-- (.cmm) preprocessor:

  * cc-options: -DTHREADED_RTS   -> C sources only
  * cpp-options: -DTHREADED_RTS  -> passed as -optP (GHC's Haskell CPP), not
                                    the C-compiler CPP that GHC uses for .cmm
  * cmm-options: -DTHREADED_RTS  -> reaches the .cmm compile, but as a bare
                                    -D, which GHC does not forward to the .cmm
                                    CPP (that needs -optc-D)
  * ghc-options: -optc-DTHREADED_RTS -> not applied to .cmm compiles at all

So StgMiscClosures.cmm's stg_WHITEHOLE_info (and other THREADED_RTS-gated Cmm) compiled on the non-threaded '#else' path -- barf("WHITEHOLE object entered!") instead of the spin-until-updated loop -- while still being linked into the threaded RTS. Under 'ghc --make -jN' any transient WHITEHOLE lock is then fatal (WHITEHOLE / Bus error / Abort trap), reproducible on aarch64-darwin.

Fix: add the -optc form to cmm-options so -DTHREADED_RTS reaches the .cmm CPP. Kept alongside the existing bare -D (harmless, and forward-compatible should cabal/GHC ever forward the bare form or the component ghc-options to .cmm). Scoped to the threaded ways (only the threaded sublibs import this stanza).